### PR TITLE
Support shorter and fractional q-path coordinates

### DIFF
--- a/pySED/My_Parsers.py
+++ b/pySED/My_Parsers.py
@@ -6,11 +6,18 @@
 '''
 
 import numpy as np
+from fractions import Fraction
 
 def print_error(txt, input_file):
     print('\nERROR: Value for input paramater "{}" seems wrong or should not exist in {}, '
           'please check it and see README.\n'.format(txt, input_file))
     exit()
+
+def parse_float_or_fraction(token):
+    try:
+        return float(token)
+    except ValueError:
+        return float(Fraction(token))
 
 class get_parse_input(object):
     def __init__(self, input_file='input_SED.in'):
@@ -184,7 +191,7 @@ class get_parse_input(object):
                     needed = (self.num_qpaths + 1) * 3
                     if len(tokens) < needed:
                         print_error('q_path', input_file)
-                    self.q_path = np.array(tokens[:needed]).astype(float)
+                    self.q_path = np.array([parse_float_or_fraction(token) for token in tokens[:needed]])
                     self.q_path = self.q_path.reshape(self.num_qpaths+1, 3)
 
                 except:
@@ -420,7 +427,7 @@ class get_parse_input(object):
             needed = (self.num_qpaths + 1) * 3
             if len(self._pending_q_path_tokens) < needed:
                 print_error('q_path', input_file)
-            self.q_path = np.array(self._pending_q_path_tokens[:needed]).astype(float)
+            self.q_path = np.array([parse_float_or_fraction(token) for token in self._pending_q_path_tokens[:needed]])
             self.q_path = self.q_path.reshape(self.num_qpaths+1, 3)
 
 if __name__ == "__main__":

--- a/pySED/construct_BZ.py
+++ b/pySED/construct_BZ.py
@@ -433,12 +433,12 @@ class BZPathHelper:
         return [f for f in fracs if 0 <= f <= 1]
 
     @staticmethod
-    def _as_commensurate_fraction(value, max_denominator=12, atol=1e-6):
+    def _as_commensurate_fraction(value, max_denominator=12, atol=1e-5):
         """
         Convert q-path coordinates to stable Fractions.
 
         Users often enter high-symmetry points as decimal approximations,
-        e.g. 0.333333 for 1/3. Treat nearby small-denominator fractions as
+        e.g. 0.33333 for 1/3. Treat nearby small-denominator fractions as
         the intended value, otherwise preserve the decimal value.
         """
         frac = Fraction(str(float(value)))


### PR DESCRIPTION
## Summary
- Relax small-denominator q-path matching tolerance from `1e-6` to `1e-5`.
- Allows shorter decimal approximations such as `0.33333` to be interpreted as the intended `1/3` high-symmetry coordinate.
- Supports explicit fraction tokens in `q_path`, such as `1/3`, `2/3`, and `-1/3`.
- Follow-up to the fix for #41.

## Verification
- Confirmed `M(0.5, 0, 0) -> K(0.33333, 0.33333, 0)` in a 50x50x1 hexagonal supercell generates 9 q-points.
- Confirmed `0.33333`, `0.333333`, `0.3333333`, and `1/3` all generate 9 q-points in the same M -> K check.
- Confirmed parser reads `q_path = ... 1/3 1/3 0.0 ...` as `0.33333333` coordinates.
- Ran `python -m py_compile pySED\My_Parsers.py pySED\construct_BZ.py`.