### PR TITLE
[codex] Refine example README links

### DIFF
--- a/example/In_plane_graphene_gpumd/README.md
+++ b/example/In_plane_graphene_gpumd/README.md
@@ -131,9 +131,9 @@ clear:
 
 - [`plot_cutoff_freq`](https://pysed.readthedocs.io/en/latest/input_parameters.html#plot-cutoff-freq)
 - [`plot_interval`](https://pysed.readthedocs.io/en/latest/input_parameters.html#plot-interval)
-- `plot_color`
-- `colorbar_min`
-- `colorbar_max`
+- [`plot_color`](https://pysed.readthedocs.io/en/latest/input_parameters.html#plot-color)
+- [`colorbar_min`](https://pysed.readthedocs.io/en/latest/input_parameters.html#colorbar-min)
+- [`colorbar_max`](https://pysed.readthedocs.io/en/latest/input_parameters.html#colorbar-max)
 
 The raw pySED figure is:
 
@@ -145,9 +145,10 @@ The raw pySED figure is:
 
 This example includes an LD comparison workflow in `SED/compare_LD/`:
 
-- `get_phonon_dispersion.py` calculates the NEP-driven LD dispersion using
-  `calorine` and `phonopy`.
-- `plot_phonon_dis_NEP_SED.py` overlays the LD branches on the pySED SED map.
+- [`get_phonon_dispersion.py`](SED/compare_LD/get_phonon_dispersion.py)
+  calculates the NEP-driven LD dispersion using `calorine` and `phonopy`.
+- [`plot_phonon_dis_NEP_SED.py`](SED/compare_LD/plot_phonon_dis_NEP_SED.py)
+  overlays the LD branches on the pySED SED map.
 
 The final comparison figure should show strong agreement between the SED
 background and LD branches.
@@ -161,4 +162,5 @@ background and LD branches.
 - [x] [`num_atoms = 3200`](https://pysed.readthedocs.io/en/latest/input_parameters.html#num-atoms) matches `basis.in` and `dump.xyz`.
 - [x] [`supercell_dim = 40 40 1`](https://pysed.readthedocs.io/en/latest/input_parameters.html#supercell-dim) matches the generated graphene supercell.
 - [x] [`output_data_stride = 10`](https://pysed.readthedocs.io/en/latest/input_parameters.html#output-data-stride) matches `dump_exyz 10 1`.
-- [x] `q_path_name = 'GMKG'` has `num_qpaths + 1` labels.
+- [x] [`q_path_name = 'GMKG'`](https://pysed.readthedocs.io/en/latest/input_parameters.html#q-path-name) has
+  [`num_qpaths + 1`](https://pysed.readthedocs.io/en/latest/input_parameters.html#num-qpaths) labels.

--- a/example/README.md
+++ b/example/README.md
@@ -10,19 +10,6 @@ Use this directory together with the
 [`input_SED.in` parameter guide](https://pysed.readthedocs.io/en/latest/input_parameters.html)
 first.
 
-Useful direct links:
-
-- [`num_atoms`](https://pysed.readthedocs.io/en/latest/input_parameters.html#num-atoms)
-- [`output_data_stride`](https://pysed.readthedocs.io/en/latest/input_parameters.html#output-data-stride)
-- [`supercell_dim`](https://pysed.readthedocs.io/en/latest/input_parameters.html#supercell-dim)
-- [`plot_SED`](https://pysed.readthedocs.io/en/latest/input_parameters.html#plot-sed)
-- [`plot_slice`](https://pysed.readthedocs.io/en/latest/input_parameters.html#plot-slice)
-- [`qpoint_slice_index`](https://pysed.readthedocs.io/en/latest/input_parameters.html#qpoint-slice-index)
-- [`peak_height`](https://pysed.readthedocs.io/en/latest/input_parameters.html#peak-height)
-- [`peak_prominence`](https://pysed.readthedocs.io/en/latest/input_parameters.html#peak-prominence)
-- [`initial_guess_hwhm`](https://pysed.readthedocs.io/en/latest/input_parameters.html#initial-guess-hwhm)
-- [`output_partial`](https://pysed.readthedocs.io/en/latest/input_parameters.html#output-partial)
-
 ---
 
 ## 🧭 Workflow Map
@@ -37,8 +24,8 @@ Each modern GPUMD example follows this sequence:
 - [x] **[4. Plot/Fit]** Run pySED with `plot_SED = 1`, then tune plotting or Lorentz fitting parameters.
 - [x] **[5. Validate]** Compare with lattice dynamics when an LD workflow is provided.
 
-For repeatable runs, you can put the structure generation, MD run, pySED
-calculation, and plotting commands into a `.sh` workflow script. See the
+For workflow automation, you can put the structure generation, MD run, pySED
+calculation, and plotting commands into a `.sh` script. See the
 [manual tips page](https://pysed.readthedocs.io/en/latest/tips.html) for a
 `run_SED.sh`-style example.
 
@@ -62,9 +49,10 @@ in the structure-generation script, then write `model.xyz` and `basis.in`.
 ## 🧩 Reference and Legacy Folders
 
 - **`Ref_Phonon_dispersion_from_phonopy`**
-  Legacy reference lattice-dynamics workflows using phonopy. They are kept for
-  checking whether SED branches agree with harmonic phonon dispersions, but
-  these older scripts may be removed or reorganized in future releases.
+  Legacy reference lattice-dynamics workflows using phonopy for previous
+  empirical-potential examples. They are kept to check whether SED branches
+  from those older workflows agree with harmonic phonon dispersions, but these
+  scripts may be removed or reorganized in future releases.
 
 - **`For_old_version_example`**
   Older LAMMPS-based and legacy workflows. Start from the modern GPUMD examples

--- a/example/Silicon_primitive_gpumd/README.md
+++ b/example/Silicon_primitive_gpumd/README.md
@@ -109,8 +109,9 @@ For the first run, use:
 plot_SED = 0
 ```
 
-After `silicon.SED`, `silicon.Qpts`, and `silicon.THz` exist, set the
-following value in `SED/input_SED.in`:
+After `silicon.SED`, `silicon.Qpts`, and `silicon.THz` exist, set
+[`plot_SED`](https://pysed.readthedocs.io/en/latest/input_parameters.html#plot-sed)
+in `SED/input_SED.in`:
 
 ```text
 plot_SED = 1
@@ -124,6 +125,11 @@ q_path_name = 'GXUKGL'
 q_path = 0.0 0.0 0.0  0.5 0.0 0.5  0.625 0.25 0.625  0.375 0.375 0.75  0.0 0.0 0.0  0.5 0.5 0.5
 ```
 
+For the q-path syntax, see
+[`num_qpaths`](https://pysed.readthedocs.io/en/latest/input_parameters.html#num-qpaths),
+[`q_path_name`](https://pysed.readthedocs.io/en/latest/input_parameters.html#q-path-name),
+and [`q_path`](https://pysed.readthedocs.io/en/latest/input_parameters.html#q-path).
+
 The raw pySED SED map is:
 
 ![Silicon SED](SED/silicon-SED.png)
@@ -134,9 +140,10 @@ The raw pySED SED map is:
 
 The `SED/compare_LD/` directory contains:
 
-- `get_phonon_dispersion.py` calculates the NEP-driven LD dispersion using
-  `calorine` and `phonopy`.
-- `plot_phonon_dis_NEP_SED.py` overlays the LD branches on the pySED SED map.
+- [`get_phonon_dispersion.py`](SED/compare_LD/get_phonon_dispersion.py)
+  calculates the NEP-driven LD dispersion using `calorine` and `phonopy`.
+- [`plot_phonon_dis_NEP_SED.py`](SED/compare_LD/plot_phonon_dis_NEP_SED.py)
+  overlays the LD branches on the pySED SED map.
 
 The final comparison figure should show strong agreement between the SED
 background and LD branches.
@@ -160,7 +167,10 @@ lorentz_fit_cutoff = 20
 
 Tune these key parameters in `SED/input_SED.in`:
 
+- [`plot_slice`](https://pysed.readthedocs.io/en/latest/input_parameters.html#plot-slice)
 - [`qpoint_slice_index`](https://pysed.readthedocs.io/en/latest/input_parameters.html#qpoint-slice-index)
+- [`lorentz`](https://pysed.readthedocs.io/en/latest/input_parameters.html#lorentz)
+- [`lorentz_fit_cutoff`](https://pysed.readthedocs.io/en/latest/input_parameters.html#lorentz-fit-cutoff)
 - [`peak_height`](https://pysed.readthedocs.io/en/latest/input_parameters.html#peak-height)
 - [`peak_prominence`](https://pysed.readthedocs.io/en/latest/input_parameters.html#peak-prominence)
 - [`initial_guess_hwhm`](https://pysed.readthedocs.io/en/latest/input_parameters.html#initial-guess-hwhm)
@@ -172,5 +182,6 @@ Tune these key parameters in `SED/input_SED.in`:
 - [x] [`num_atoms = 16000`](https://pysed.readthedocs.io/en/latest/input_parameters.html#num-atoms) matches `basis.in` and `dump.xyz`.
 - [x] [`supercell_dim = 20 20 20`](https://pysed.readthedocs.io/en/latest/input_parameters.html#supercell-dim) matches the generated silicon supercell.
 - [x] [`output_data_stride = 10`](https://pysed.readthedocs.io/en/latest/input_parameters.html#output-data-stride) matches `dump_exyz 10 1`.
-- [x] `prim_unitcell` is consistent with the primitive silicon cell.
-- [x] `q_path_name = 'GXUKGL'` has `num_qpaths + 1` labels.
+- [x] [`prim_unitcell`](https://pysed.readthedocs.io/en/latest/input_parameters.html#prim-unitcell) is consistent with the primitive silicon cell.
+- [x] [`q_path_name = 'GXUKGL'`](https://pysed.readthedocs.io/en/latest/input_parameters.html#q-path-name) has
+  [`num_qpaths + 1`](https://pysed.readthedocs.io/en/latest/input_parameters.html#num-qpaths) labels.


### PR DESCRIPTION
## Summary

- Simplify the top-level example/README.md by removing the long direct-link parameter list.
- Clarify that Ref_Phonon_dispersion_from_phonopy serves previous empirical-potential examples.
- Reword the .sh note as workflow automation guidance.
- Add missing direct links for Graphene and Silicon README parameters and LD helper scripts.

## Validation

- Ran git diff --check.
- Verified the changed file set is limited to the three requested example README files.