### PR TITLE
Clean up input parameter documentation

### DIFF
--- a/docs/source/input_parameters.rst
+++ b/docs/source/input_parameters.rst
@@ -1,7 +1,8 @@
-input_SED.in Parameters
-=======================
+Input Parameters
+================
 
-pySED reads a plain-text control file, usually named ``input_SED.in``. Each
+pySED reads a plain-text control file. The default file name is
+``input_SED.in``, but another file name can be passed on the command line. Each
 active line has the form
 
 .. code-block:: text
@@ -17,27 +18,14 @@ command line, pySED reads ``input_SED.in`` in the current directory:
    pysed input_SED.in
    pySED input_SED.in
 
-.. rubric:: Example ``input_SED.in``
-
-The following input file is the MoS\ :sub:`2` GPUMD example from
-`example/MoS2_gpumd/SED/input_SED.in <https://github.com/Tingliangstu/pySED/blob/main/example/MoS2_gpumd/SED/input_SED.in>`_.
-It shows a complete workflow, including MD trajectory settings, structure
-settings, q-path settings, plotting, and Lorentzian fitting options.
-
-.. literalinclude:: ../../example/MoS2_gpumd/SED/input_SED.in
-   :language: text
-   :caption: MoS\ :sub:`2` GPUMD ``input_SED.in`` example
-
-This page is the entry point for parameters accepted by ``input_SED.in``. The
-same parameter list is also shown under **input_SED.in Parameters** in the left
-sidebar, so users can jump directly to one parameter page from any page in this
-section. Each parameter page has the parameter name as its title and includes
-syntax, meaning, defaults, examples, practical notes, and related parameters.
+The table below lists the parameters accepted by the pySED input file. Each
+parameter has its own page with the parameter name as the title, plus syntax,
+meaning, defaults, examples, practical notes, and related parameters.
 
 .. toctree::
    :hidden:
    :maxdepth: 1
-   :caption: input_SED.in parameters
+   :caption: Input file parameters
 
    input_parameters/num_atoms
    input_parameters/total_num_steps
@@ -152,7 +140,7 @@ syntax, meaning, defaults, examples, practical notes, and related parameters.
 
 .. rst-class:: parameter-index
 
-.. list-table:: ``input_SED.in`` parameter pages
+.. list-table::
    :header-rows: 1
    :widths: 24 24 52
 

--- a/docs/source/input_parameters/output_data_stride.rst
+++ b/docs/source/input_parameters/output_data_stride.rst
@@ -34,6 +34,11 @@ output_data_stride
       \frac{500}
       {\mathrm{time\_step(fs)} \times \mathrm{output\_data\_stride}}.
 
+   This is the usual Nyquist limit,
+   ``f_max = 1 / (2 * time_step * output_data_stride)``. The factor ``500``
+   comes only from unit conversion: when ``time_step`` is given in fs, ``1/fs``
+   equals ``1000`` THz, and the Nyquist factor ``1/2`` gives ``1000 / 2 = 500``.
+
    For example, if ``time_step = 1`` fs and ``output_data_stride = 50``, the
    maximum resolvable frequency is ``10`` THz. Modes above this frequency
    cannot be recovered from the saved trajectory.

--- a/docs/source/input_parameters/peak_max_hwhm.rst
+++ b/docs/source/input_parameters/peak_max_hwhm.rst
@@ -15,7 +15,8 @@ peak_max_hwhm
    ``1e6``.
 
 **Notes**
-   Set a smaller value when broad or noisy peaks cause unreasonable fits.
+   In most cases, this parameter does not need to be adjusted. Set a smaller
+   value only when broad or noisy peaks cause unreasonable Lorentzian fits.
 
 :doc:`Back to Parameter Index <../input_parameters>`
 


### PR DESCRIPTION
## Summary
- Rename the input parameter index page to `Input Parameters` and clarify that the control file can use a custom file name.
- Remove the example `input_SED.in` block from the parameter index page and simplify the parameter table heading.
- Explain that the `500` factor in the `output_data_stride` frequency formula comes from fs-to-THz conversion and the Nyquist factor.
- Note that `peak_max_hwhm` usually does not need to be adjusted.

## Validation
- `python -m sphinx -b html docs\source docs\_build\html`
- Checked rendered HTML for the new page title, removed example section/table caption, `output_data_stride` formula explanation, and `peak_max_hwhm` note.