### PR TITLE
Fix MoS2 starting guide link

### DIFF
--- a/docs/source/starting.rst
+++ b/docs/source/starting.rst
@@ -118,7 +118,7 @@ Start with an existing example before applying pySED to a new system:
 
 - 1D: `CNT <https://github.com/Tingliangstu/pySED/tree/main/example/CNT>`_
 - 2D: `Graphene <https://github.com/Tingliangstu/pySED/tree/main/example/In_plane_graphene_gpumd>`_
-  or `MoS\ :sub:`2` <https://github.com/Tingliangstu/pySED/tree/main/example/MoS2_gpumd>`_
+  or `MoS₂ <https://github.com/Tingliangstu/pySED/tree/main/example/MoS2_gpumd>`_
 - 3D: `Silicon <https://github.com/Tingliangstu/pySED/tree/main/example/Silicon_primitive_gpumd>`_
 
 If one of these examples reproduces the expected SED image, your installation


### PR DESCRIPTION
## Summary
- Fix the Recommended First Examples MoS2 link so the label renders as `MoS₂` instead of malformed `MoS:sub:` text.

## Validation
- `python -m sphinx -b html docs\source docs\_build\html`
- Checked generated `starting.html` for the MoS₂ label, correct link target, and absence of the bad `:sub:` text.