### PR TITLE
[codex] Add scattering workflows and q-advisor input mode

### DIFF
--- a/benchmarks/dsf_reference_validation.py
+++ b/benchmarks/dsf_reference_validation.py
@@ -1,0 +1,100 @@
+"""Reference validation entry point for pySED scattering development."""
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from pySED.validation import (
+    build_dsf_validation_report,
+    compare_external_dsf_reference,
+    export_dsf_validation_case,
+    write_validation_report,
+)
+
+
+def _print_report_summary(report):
+    internal = report["internal"]
+    coherent = internal["checks"]["coherent"]
+    coherent_sem = internal["checks"]["coherent_sem"]
+    print("pySED direct-vs-correlation max_abs =", coherent["max_abs"])
+    print("pySED direct-vs-correlation sem_max_abs =", coherent_sem["max_abs"])
+    for package in report["external"]["packages"]:
+        print("%s installed = %s" % (package["module"], package["installed"]))
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tolerance", type=float, default=1e-12)
+    parser.add_argument("--json", dest="json_path", help="Write a structured JSON report")
+    parser.add_argument("--export-case", help="Export the synthetic validation case as .npz")
+    parser.add_argument("--compare-reference", help="Compare pySED with an external DSF .npz spectrum")
+    parser.add_argument("--reference-key", default="coherent", help="Spectrum key in --compare-reference")
+    parser.add_argument("--reference-frequency-key", help="Frequency-axis key in --compare-reference")
+    parser.add_argument(
+        "--candidate-component",
+        default="coherent",
+        help="pySED DSF result component to compare against the external spectrum",
+    )
+    parser.add_argument(
+        "--normalization",
+        default="least_squares",
+        choices=("none", "max", "least_squares"),
+        help="Normalization used for external spectrum comparison",
+    )
+    parser.add_argument("--rmse-tolerance", type=float, help="Optional normalized-RMSE pass threshold")
+    parser.add_argument("--comparison-json", help="Write external comparison metrics as JSON")
+    parser.add_argument(
+        "--require-external",
+        action="store_true",
+        help="Fail if neither dynasor nor pynamic-style package is importable",
+    )
+    args = parser.parse_args(argv)
+
+    report = build_dsf_validation_report(tolerance=args.tolerance)
+    _print_report_summary(report)
+
+    if args.json_path:
+        write_validation_report(report, args.json_path)
+        print("validation report written =", args.json_path)
+
+    if args.export_case:
+        export_dsf_validation_case(args.export_case)
+        print("validation case exported =", args.export_case)
+
+    if args.compare_reference:
+        comparison = compare_external_dsf_reference(
+            args.compare_reference,
+            reference_key=args.reference_key,
+            reference_frequency_key=args.reference_frequency_key,
+            component=args.candidate_component,
+            normalization=args.normalization,
+            rmse_tolerance=args.rmse_tolerance,
+        )
+        print("external comparison normalized_rmse =", comparison["normalized_rmse"])
+        print("external comparison correlation =", comparison["correlation"])
+        print("external comparison scale_factor =", comparison["scale_factor"])
+        if args.comparison_json:
+            write_validation_report(comparison, args.comparison_json)
+            print("external comparison report written =", args.comparison_json)
+        if not comparison["passed"]:
+            raise SystemExit("external DSF reference comparison failed")
+
+    if args.require_external:
+        installed = {
+            package["module"]
+            for package in report["external"]["packages"]
+            if package.get("installed") and package.get("importable", True)
+        }
+        if not ({"dynasor", "psf", "pynamic_structure_factor", "pynamic"} & installed):
+            raise SystemExit("external DSF validation package is required but unavailable")
+
+    if not report["passed"]:
+        raise SystemExit("internal DSF reference validation failed")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,7 +17,13 @@ release = '2.4.0'
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ['recommonmark', 'sphinx_markdown_tables', 'nbsphinx', 'sphinx.ext.mathjax']
+extensions = [
+    'recommonmark',
+    'sphinx_markdown_tables',
+    'nbsphinx',
+    'sphinx.ext.mathjax',
+    'sphinx.ext.autodoc',
+]
 
 templates_path = ['_templates']
 exclude_patterns = ['notebook/Test_num_qpoints.ipynb']

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,6 +23,8 @@ maps, and fit Lorentzian peaks to estimate phonon lifetimes.
    tutorials
    example
    theory
+   scattering
+   scattering_api
    tips
    publications
    reference

--- a/docs/source/input_parameters.rst
+++ b/docs/source/input_parameters.rst
@@ -22,6 +22,38 @@ The table below lists the parameters accepted by the pySED input file. Each
 parameter has its own page with the parameter name as the title, plus syntax,
 meaning, defaults, examples, practical notes, and related parameters.
 
+Experimental Scattering/Q-Advisor Mode
+--------------------------------------
+
+The scattering extension can also be launched from ``input_SED.in``.  The first
+CLI-facing mode is the q-advisor, which checks whether requested experimental
+``Q`` points are commensurate with the finite MD supercell before DSF, EELS, or
+mode-resolved visibility calculations are attempted.
+
+.. code-block:: text
+
+   scattering = 1
+   scattering_mode = q_advisor
+   scattering_qpoints_option = path
+   scattering_qpoint_coordinates = reduced
+   scattering_q_policy = strict
+   scattering_q_path_steps = 4
+   scattering_output_prefix = q_eels_advisor
+
+   prim_unitcell = 1 0 0  0 1 0  0 0 1
+   supercell_dim = 4 4 1
+   num_qpaths = 1
+   q_path = 0.0 0.0 0.0  0.5 0.0 0.0
+
+``scattering_qpoints_option`` may be ``path`` (reuse ``q_path``), ``mesh``
+(``scattering_q_mesh_H/K/L`` are scalar or ``start stop num`` axes), ``file``
+(``scattering_q_file`` contains one Q point per row), or ``points`` (inline
+triplets through ``scattering_qpoints``).  ``scattering_q_policy = strict``
+rejects non-commensurate points after writing the nearest-Q report, while
+``nearest`` accepts the nearest commensurate points.  The q-advisor writes CSV
+and text summaries, nearest reduced Q points, and folded phonopy Q points for
+subsequent DSF/EELS workflows.
+
 .. toctree::
    :hidden:
    :maxdepth: 1

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -28,6 +28,24 @@ Navigate to the downloaded directory and install using one of the following meth
     cd pySED
     pip install .
 
+The default installation is CPU-only and does not require any CUDA packages.
+For optional CuPy acceleration in the pySED scattering kernels, choose the extra
+that matches your CUDA runtime:
+
+.. code-block:: bash
+
+    pip install ".[gpu-cuda12x]"
+
+or, for CUDA 11.x environments:
+
+.. code-block:: bash
+
+    pip install ".[gpu-cuda11x]"
+
+Then request the GPU backend explicitly in the scattering API, for example
+``compute_dsf(..., backend="cupy")``.  If CuPy is not installed, the CPU backend
+remains available through ``backend="cpu"``.
+
 **Alternative method (via setup script):**
 
 .. code-block:: bash

--- a/docs/source/requirements.rst
+++ b/docs/source/requirements.rst
@@ -13,4 +13,18 @@ Mandatory requirements
 - h5py (Used to compress large trajectories files)
 - scipy (For fast Lorentz fitting)
 
+Optional GPU requirements
+-------------------------
+The default pySED installation is CPU-only.  The scattering kernels can use a
+CuPy backend when the user explicitly requests it and installs a CUDA-specific
+CuPy wheel:
+
+- ``pip install ".[gpu-cuda12x]"`` for CUDA 12.x
+- ``pip install ".[gpu-cuda11x]"`` for CUDA 11.x
+
+GPU acceleration is opt-in because CuPy wheels depend on the local CUDA runtime.
+Use ``backend="cupy"`` in the DSF/current-correlation APIs after installing the
+matching CuPy package.  Use ``backend="cpu"`` or omit the backend argument for
+the standard NumPy/SciPy path.
+
 

--- a/docs/source/scattering.rst
+++ b/docs/source/scattering.rst
@@ -1,0 +1,1782 @@
+Scattering Extensions
+=====================
+
+This page records the theoretical and implementation basis for the new
+experiment-facing scattering modules in pySED.  The design goal is not to copy
+dynasor, pynamic-structure-factor, or PySlice, but to provide a pySED-native
+route from MD trajectories to experiment-comparable phonon scattering maps with
+mode-level interpretation.
+
+The modules currently added are:
+
+- :mod:`pySED.scattering_kernel`: shared phase, density-amplitude, time-FFT,
+  and block-statistics kernels.
+- :mod:`pySED.probe_weights`: neutron/X-ray probe weights, including
+  q-dependent Cromer-Mann X-ray form factors.
+- :mod:`pySED.quantum_correction`: optional classical-to-quantum
+  detailed-balance corrections and energy-axis conversion.
+- :mod:`pySED.q_advisor`: commensurate q-point validation, nearest-q mapping,
+  finite-size warnings, and supercell suggestions.
+- :mod:`pySED.dsf`: coherent and incoherent neutron dynamic structure factors,
+  X-ray weighted DSF, and longitudinal/transverse current spectra.
+- :mod:`pySED.mode_visibility`: coherent one-phonon neutron/X-ray
+  mode-visibility diagnostics from eigenvectors.
+- :mod:`pySED.visibility_diagnostics`: branch-level reason labels for
+  polarization selection, basis interference, finite-size q mapping, and weak
+  experimental visibility.
+- :mod:`pySED.eigen_sed`: phonopy-eigenvector projection for branch-resolved
+  SED.
+- :mod:`pySED.electron_kinematics`: relativistic electron wavelength and
+  small-angle q-EELS momentum-axis calibration.
+- :mod:`pySED.eels`: first kinematic q-EELS visibility and extended-zone maps.
+- :mod:`pySED.compare_experiment`: broadening, smoothing, normalization,
+  residual maps, line cuts, and peak tracking for experimental comparison.
+- :mod:`pySED.scattering_plot`: publication-style map, residual, and line-cut
+  plotting helpers.
+- :mod:`pySED.scattering_workflow`: high-level workflow wrappers that connect
+  commensurate q validation, eigenvector SED, extended-zone EELS visibility,
+  and optional experiment-map comparison.
+- :mod:`pySED.scattering_export`: reproducibility bundles for q-plans,
+  simulated maps, visibility diagnostics, and comparison tables.
+
+The core innovation is a unified scattering kernel:
+
+.. math::
+
+   \mathrm{MD\ trajectory}
+   \rightarrow
+   \left\{
+   \Phi(\mathbf{q},\omega),
+   S(\mathbf{Q},\omega),
+   I_{\mathrm{EELS}}(\mathbf{Q},\omega)
+   \right\},
+
+where the same finite-supercell q-point rules are used for SED, DSF, EELS, and
+mode projection.
+
+The low-level implementation is centralized in
+:mod:`pySED.scattering_kernel`.  This module contains the shared CPU/CuPy-ready
+kernels for
+
+.. math::
+
+   e^{i\mathbf{Q}\cdot\mathbf{r}_i(t)},\quad
+   \rho_w(\mathbf{Q},t),\quad
+   |\mathrm{FFT}_t[\rho_w]|^2,
+
+as well as block slicing and standard-error estimates.  Keeping these
+operations in one module is intentional: optional GPU implementations can
+replace this kernel layer without changing the DSF/EELS theory or high-level
+user API.
+
+The default backend is CPU/NumPy:
+
+.. code-block:: python
+
+   result = compute_dsf(positions, qpoints, dt, backend="cpu")
+
+Users with a compatible CUDA environment can request the optional CuPy backend:
+
+.. code-block:: python
+
+   result = compute_dsf(positions, qpoints, dt, backend="cupy")
+
+The eigenvector-projected SED path uses the same backend mechanism:
+
+.. code-block:: python
+
+   eigen_sed = compute_eigen_sed(..., backend="cupy")
+   eels = compute_eels_workflow(..., sed_backend="cupy")
+   ixs = compute_one_phonon_workflow(..., sed_backend="cupy")
+
+CuPy is not a pySED hard dependency because CUDA wheels are platform- and
+runtime-specific.  Users should install the CuPy package that matches their own
+CUDA runtime, for example ``pip install ".[gpu-cuda12x]"`` or
+``pip install ".[gpu-cuda11x]"`` from the pySED source tree.  If CuPy is not
+installed, pySED raises a clear error and the CPU path remains available.  The
+current GPU coverage targets the numerically heavy selected-Q density FFTs,
+current correlations, and eigenvector SED projection/FFT.  The lightweight
+visibility weighting, q-advisor, and experimental comparison steps remain CPU
+NumPy operations.  This keeps GPU acceleration opt-in and avoids forcing
+non-GPU users to compile or install GPU packages.
+
+Commensurate Q Points
+---------------------
+
+For a primitive cell :math:`\mathbf{p}` and a simulation supercell
+:math:`\mathbf{S}`, both written with lattice vectors as rows,
+
+.. math::
+
+   \mathbf{S} = \mathbf{P}\mathbf{p},
+
+where :math:`\mathbf{P}` is an integer repetition matrix.  The reciprocal basis
+of the primitive cell is
+
+.. math::
+
+   \mathbf{B}_p = 2\pi(\mathbf{p}^{-1})^T.
+
+A reduced wave vector :math:`\mathbf{q}_{\mathrm{red}}` is compatible with the
+periodic MD trajectory only when
+
+.. math::
+
+   \mathbf{q}_{\mathrm{red}}\mathbf{P}^{T} \in \mathbb{Z}^3.
+
+For a diagonal supercell
+:math:`\mathbf{P}=\mathrm{diag}(N_x,N_y,N_z)`, this reduces to the familiar
+grid
+
+.. math::
+
+   \mathbf{q}_{\mathrm{red}}
+   =
+   \left(
+   \frac{n_x}{N_x},
+   \frac{n_y}{N_y},
+   \frac{n_z}{N_z}
+   \right).
+
+Non-commensurate wave vectors are not simply "slightly interpolated" phonons.
+They violate the periodic boundary condition of the finite trajectory.  In a
+direct Fourier transform, this appears as finite-window leakage or spurious
+intensity.  Therefore, pySED should reject or explicitly label
+non-commensurate q points by default.
+
+The :mod:`pySED.q_advisor` module exposes this condition directly.  It can:
+
+- validate requested q points,
+- enumerate the finite-supercell commensurate grid,
+- construct only the allowed points on a high-symmetry path,
+- map an experimental :math:`\mathbf{Q}` to the nearest commensurate point,
+  either from reduced coordinates or directly from Cartesian reciprocal-space
+  coordinates,
+- report the reduced and Cartesian error, and
+- suggest diagonal supercell repeats for a target set of experimental q
+  points.
+
+This differs from pynamic-structure-factor in an important way.  pynamic uses
+direct user-supplied Q points and parallelizes over them, which is efficient
+for selected experimental paths and maps.  Its documentation also warns that
+the user must choose Q points commensurate with the simulation cell.  Therefore
+pynamic's advantage is the direct selected-Q estimator, not a more rigorous
+q-point algorithm.  pySED keeps the stricter q-advisor layer and uses the
+direct selected-Q estimator where appropriate.
+
+Pynamic-style Selected-Q Grids
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The selected-Q idea is useful and should be kept.  The point is not that the
+Q-point generation itself is mathematically superior; the point is that the
+calculation is restricted to the experimental vectors that will actually be
+plotted or compared.  For a selected set
+:math:`\mathcal{Q}_{\mathrm{sel}}=\{\mathbf{Q}_{\ell}\}_{\ell=1}^{N_Q}` and a
+block of :math:`N_t` trajectory frames, pySED evaluates
+
+.. math::
+
+   \rho_w(\mathbf{Q}_{\ell},t_n)
+   =
+   \sum_{i=1}^{N}
+   w_i(\mathbf{Q}_{\ell})
+   \exp[
+   i\mathbf{Q}_{\ell}\cdot\mathbf{r}_i(t_n)]
+
+and then
+
+.. math::
+
+   S_w(\mathbf{Q}_{\ell},\omega_k)
+   =
+   \frac{1}{N N_t}
+   \left|
+   \sum_{n=0}^{N_t-1}
+   \rho_w(\mathbf{Q}_{\ell},t_n)
+   \exp(-i2\pi kn/N_t)
+   \right|^2 .
+
+This is the same finite-time estimator as the pynamic manual's direct
+expression for :math:`S(\mathbf{Q},\omega)` [ScatPynamic2025]_, and it is the
+efficient production form used by :func:`pySED.dsf.compute_dsf`.
+
+For a selected rectangular mesh in reciprocal-lattice units, pySED uses
+
+.. math::
+
+   H_a = H_{\min}
+   +
+   \frac{a}{N_H-1}(H_{\max}-H_{\min}),
+   \quad
+   K_b = K_{\min}
+   +
+   \frac{b}{N_K-1}(K_{\max}-K_{\min}),
+   \quad
+   L_c = L_{\min}
+   +
+   \frac{c}{N_L-1}(L_{\max}-L_{\min}),
+
+and forms
+
+.. math::
+
+   \mathbf{Q}_{abc}
+   =
+   H_a\mathbf{b}_1
+   +
+   K_b\mathbf{b}_2
+   +
+   L_c\mathbf{b}_3 .
+
+For selected paths, segment :math:`s` is sampled as
+
+.. math::
+
+   \mathbf{Q}_{s,m}
+   =
+   \mathbf{Q}^{\mathrm{start}}_s
+   +
+   \frac{m}{M_s}
+   \left(
+   \mathbf{Q}^{\mathrm{end}}_s
+   -
+   \mathbf{Q}^{\mathrm{start}}_s
+   \right),
+   \qquad
+   m=0,\ldots,M_s-1,
+
+so consecutive path segments do not duplicate shared vertices.  These selected
+points are generated by :func:`pySED.q_advisor.qpoints_from_mesh` and
+:func:`pySED.q_advisor.qpoints_from_path_segments`:
+
+.. code-block:: python
+
+   from pySED.q_advisor import QAdvisor, qpoints_from_mesh, qpoints_from_path_segments
+
+   mesh = qpoints_from_mesh([-1, 1, 41], [-1, 1, 41], 0.0)
+   path = qpoints_from_path_segments(
+       starts=[[0, 0, 0], [1, 0, 0]],
+       ends=[[1, 0, 0], [1, 1, 0]],
+       steps=[40, 40],
+   )
+
+   advisor = QAdvisor(primitive_cell, md_supercell)
+   report = advisor.advise_experimental_path(mesh.qpoints_reduced, coordinates="reduced")
+
+Only after this generation step does pySED apply the finite-supercell
+commensurability policy.  The workflow is therefore:
+
+.. math::
+
+   \mathrm{selected\ experimental\ } \mathbf{Q}
+   \rightarrow
+   \mathrm{commensurability\ report}
+   \rightarrow
+   \rho(\mathbf{Q},t)
+   \rightarrow
+   S(\mathbf{Q},\omega).
+
+The computational cost of the selected-Q direct route is approximately
+
+.. math::
+
+   \mathcal{O}(N_Q N_t N)
+   +
+   \mathcal{O}(N_Q N_t\log N_t),
+
+where the first term is the phase/density construction and the second term is
+the time FFT.  This is more efficient than evaluating every finite-supercell
+commensurate point when
+:math:`N_Q \ll |\det \mathbf{P}|`, or every point on a dense visualization
+mesh when only a line cut or experimental detector window is needed.  It is
+not a license to use arbitrary incommensurate Q points: the same periodicity
+condition
+
+.. math::
+
+   \exp(i\mathbf{Q}\cdot\mathbf{R}_s)=1
+
+for every supercell lattice vector :math:`\mathbf{R}_s` still applies, giving
+the reduced-coordinate rule
+:math:`\mathbf{q}_{\mathrm{red}}\mathbf{P}^T\in\mathbb{Z}^3`.
+
+The q-advisor can report this expected saving before a calculation:
+
+.. code-block:: python
+
+   efficiency = advisor.estimate_selected_q_efficiency(
+       mesh.qpoints_reduced,
+       num_frames=trajectory_num_frames,
+       num_atoms=num_atoms,
+   )
+   print(efficiency.to_table())
+
+The reported ``qpoint_reduction_factor`` is
+
+.. math::
+
+   R_Q
+   =
+   \frac{|\det \mathbf{P}|}
+        {N_Q^{\mathrm{selected}}},
+
+where :math:`|\det\mathbf{P}|` is the number of distinct commensurate q points
+in the finite supercell.  This is an upper-bound style Q-count estimate: the
+actual wall-time speedup also depends on memory layout, CPU/GPU backend, form
+factor evaluation, block size, and I/O.  It is still useful for planning
+because the dominant phase construction scales linearly with
+:math:`N_Q`.
+
+For neutron, X-ray, and EELS comparison the experimental vector may be an
+extended-zone vector,
+
+.. math::
+
+   \mathbf{Q}
+   =
+   \mathbf{q}
+   +
+   \mathbf{G}.
+
+The commensurability check is applied to the full reduced
+:math:`\mathbf{Q}_{\mathrm{red}}`, not only to the folded first-BZ
+:math:`\mathbf{q}`.  This matters because :math:`\mathbf{G}` can change the
+atomic form factor and basis-interference phase.  Therefore, when pySED maps a
+non-commensurate experimental point to the nearest allowed point, the high-level
+DSF workflow preserves the reciprocal-lattice image:
+
+.. math::
+
+   \mathbf{Q}_{\mathrm{red}}=1.26
+   \rightarrow
+   1.25,
+   \qquad
+   \mathrm{not}
+   \quad
+   0.25.
+
+The recommended user entry point is
+:func:`pySED.scattering_workflow.compute_dsf_workflow`:
+
+.. code-block:: python
+
+   from pySED.scattering_workflow import compute_dsf_workflow
+
+   result = compute_dsf_workflow(
+       positions,
+       qpoints=experimental_Q_cartesian,
+       primitive_cell=primitive_cell,
+       supercell_cell=md_supercell,
+       dt=1.0e-12,
+       qpoint_coordinates="cartesian",
+       q_policy="nearest",       # or "strict"
+       max_error_cartesian=0.02,
+       atom_types=atom_types,
+       experiment="xray",
+       map_component="total",    # "coherent" or "incoherent" are also allowed
+       output_energy_unit="meV",
+       experimental_map=ixs_map,
+       sigma_energy=1.5,
+   )
+
+``q_policy="strict"`` raises an error for any non-commensurate point.
+``q_policy="nearest"`` computes at the nearest commensurate point and stores
+the requested-to-used mapping in ``result.q_advice``.  This makes finite-size
+approximations visible in the output rather than hiding them inside the DSF.
+The same workflow converts the selected DSF component into
+``result.scattering_map`` and, when an experimental map is supplied, stores a
+resolution-broadened residual comparison in ``result.comparison``.  This puts
+DSF on the same paper-ready map path as the EELS and one-phonon visibility
+workflows.
+
+Before running an expensive trajectory transform, users can create a standalone
+Experiment-Q Advisor report:
+
+.. code-block:: python
+
+   from pySED.q_advisor import QAdvisor
+
+   advisor = QAdvisor(primitive_cell, md_supercell)
+   report = advisor.advise_experimental_path(
+       experimental_Q_cartesian,
+       coordinates="cartesian",
+       preserve_image=True,
+   )
+
+   print(report.to_table())
+   report.write_csv("q_advisor_report.csv")
+
+The report records which experimental points are already commensurate, the
+nearest commensurate reduced and Cartesian vectors, the error introduced by
+nearest-point mapping, the finite-supercell integer index
+:math:`\mathbf{q}_{\mathrm{red}}\mathbf{P}^T`, and a diagonal-supercell
+recommendation that would make all requested points exactly commensurate.  This
+is the practical guardrail behind pySED's claim that finite-size q sampling is
+explicit rather than hidden.
+
+When the experimental data come from a calibrated q-EELS/IXS/INS image, the
+image object already contains a scalar q axis but not necessarily the full
+three-dimensional reciprocal vector at each pixel column.  pySED handles this
+by asking for the vector endpoints of the plotted path and interpolating the
+vector :math:`\mathbf{Q}` along the calibrated axis:
+
+.. math::
+
+   \mathbf{Q}_i
+   =
+   \mathbf{Q}_{\mathrm{start}}
+   +
+   \frac{s_i-s_0}{s_N-s_0}
+   \left(
+   \mathbf{Q}_{\mathrm{end}}-\mathbf{Q}_{\mathrm{start}}
+   \right),
+
+where :math:`s_i` is the scalar q-axis value stored in the experimental map.
+Use :func:`pySED.q_advisor.qpoints_from_path_axis` for this interpolation, or
+use the :class:`pySED.q_advisor.QAdvisor` convenience methods directly:
+
+.. code-block:: python
+
+   experimental_map = load_scattering_map_image(
+       "experimental_qeels.png",
+       q_range=(0.0, 2.0),       # scalar path coordinate on the image
+       energy_range=(0.0, 180.0),
+   )
+
+   advisor = QAdvisor(primitive_cell, md_supercell)
+   q_plan = advisor.plan_map_q_axis(
+       experimental_map,
+       start_qpoint=Q_start_cartesian,
+       end_qpoint=Q_end_cartesian,
+       coordinates="cartesian",
+       q_policy="nearest",
+       max_error_cartesian=0.02,
+   )
+
+``q_plan.qpoints_reduced`` are the folded commensurate q points to pass to
+phonopy/eigen-SED, while ``q_plan.g_vectors_reduced`` retains the extended-zone
+image for EELS, INS, and IXS visibility.
+
+Dynamic Structure Factor
+------------------------
+
+The orthodox correlation-function route starts from the Van Hove
+density-density correlation function [ScatVanHove1954]_.  For atoms of type
+:math:`A`, define the spatial Fourier component of the microscopic density as
+
+.. math::
+
+   \rho_A(\mathbf{Q},t)
+   =
+   \sum_{i\in A}
+   \exp[i\mathbf{Q}\cdot\mathbf{r}_i(t)] .
+
+The partial intermediate scattering function is
+
+.. math::
+
+   F_{AB}(\mathbf{Q},t)
+   =
+   \frac{1}{\sqrt{N_A N_B}}
+   \left<
+   \rho_A(\mathbf{Q},t)
+   \rho_B(-\mathbf{Q},0)
+   \right>,
+
+and the partial dynamic structure factor is its time Fourier transform,
+
+.. math::
+
+   S_{AB}(\mathbf{Q},\omega)
+   =
+   \frac{1}{2\pi}
+   \int_{-\infty}^{\infty}
+   F_{AB}(\mathbf{Q},t)
+   e^{-i\omega t}\,dt .
+
+For a probe with complex scattering weights :math:`w_A(\mathbf{Q})`, the
+coherent probe-specific DSF is obtained by the weighted sum
+
+.. math::
+
+   S_{\mathrm{coh}}(\mathbf{Q},\omega)
+   =
+   \sum_{A,B}
+   w_A(\mathbf{Q})
+   w_B^*(\mathbf{Q})
+   S_{AB}(\mathbf{Q},\omega).
+
+This is the correlation-function language used by dynasor 2 [ScatDynasor2025]_.
+It is the safest theoretical basis for publication because it connects directly
+to Van Hove functions, partial correlations, and probe-specific scattering
+weights.
+
+Direct Estimator Used in pySED
+------------------------------
+
+For efficient computation on selected experimental Q points, pySED also uses
+the equivalent direct density-amplitude estimator.  Define
+
+.. math::
+
+   \rho_w(\mathbf{Q},t)
+   =
+   \sum_i
+   w_i(\mathbf{Q})
+   \exp[i\mathbf{Q}\cdot\mathbf{r}_i(t)] .
+
+For a finite trajectory block of duration :math:`T`, the coherent spectrum is
+estimated as
+
+.. math::
+
+   S_{\mathrm{coh}}(\mathbf{Q},\omega)
+   \approx
+   \frac{1}{N T}
+   \left|
+   \int_0^T
+   \rho_w(\mathbf{Q},t)e^{-i\omega t}\,dt
+   \right|^2,
+
+with block averaging used to estimate uncertainty and reduce noise.  This is
+equivalent to Fourier transforming the density-density correlation function
+under the usual finite-time and ergodic approximations, but it avoids storing
+:math:`F(\mathbf{Q},t)` explicitly.  This is the practical algorithmic idea
+used by pynamic-structure-factor [ScatPynamic2025]_.
+
+If the trajectory is split into :math:`N_b` blocks, pySED stores the block
+estimate
+
+.. math::
+
+   S_b(\mathbf{Q},\omega)
+   =
+   \frac{1}{N T_b}
+   \left|
+   \int_{b}
+   \rho_w(\mathbf{Q},t)e^{-i\omega t}\,dt
+   \right|^2,
+
+and returns both the block mean
+
+.. math::
+
+   \bar{S}(\mathbf{Q},\omega)
+   =
+   \frac{1}{N_b}
+   \sum_{b=1}^{N_b}
+   S_b(\mathbf{Q},\omega)
+
+and the standard error
+
+.. math::
+
+   \mathrm{SEM}[S(\mathbf{Q},\omega)]
+   =
+   \frac{\mathrm{std}_b[S_b(\mathbf{Q},\omega)]}
+   {\sqrt{N_b}}.
+
+The same convention is used for the coherent, incoherent, and total spectra.
+
+The current implementation in :func:`pySED.dsf.compute_dsf` evaluates
+
+.. math::
+
+   \rho_w(\mathbf{Q},t_n)
+   =
+   \sum_i
+   w_i(\mathbf{Q})
+   \exp[i\mathbf{Q}\cdot\mathbf{r}_i(t_n)]
+
+for each requested :math:`\mathbf{Q}` and applies a time FFT:
+
+.. math::
+
+   S_{\mathrm{coh}}(\mathbf{Q},\omega_k)
+   \propto
+   \left|
+   \mathrm{FFT}_t[\rho_w(\mathbf{Q},t)]
+   \right|^2 .
+
+For validation and small reference calculations,
+:func:`pySED.dsf.compute_coherent_dsf_via_correlation` explicitly constructs
+the finite-block intermediate scattering function
+
+.. math::
+
+   F_w(\mathbf{Q},m\Delta t)
+   =
+   \frac{1}{N_t}
+   \sum_{n=0}^{N_t-1}
+   \rho_w(\mathbf{Q},t_n+m\Delta t)
+   \rho_w^*(\mathbf{Q},t_n),
+
+with circular indexing inside each block, and then computes
+
+.. math::
+
+   S_w(\mathbf{Q},\omega_k)
+   \propto
+   \mathcal{F}_m[
+   F_w(\mathbf{Q},m\Delta t)].
+
+This reference path is slower, but it is useful for testing the equivalence
+between the correlation-function formula used in the paper and the direct
+selected-Q estimator used in production.
+
+For species-resolved interpretation,
+:func:`pySED.dsf.compute_partial_dsf` computes the coherent partial spectra
+directly from the type-resolved density amplitudes.  With
+
+.. math::
+
+   \rho_A(\mathbf{Q},t)
+   =
+   \sum_{i\in A}
+   \exp[i\mathbf{Q}\cdot\mathbf{r}_i(t)],
+
+the finite-block direct partial estimator is
+
+.. math::
+
+   S_{AB}(\mathbf{Q},\omega_k)
+   \propto
+   \mathcal{F}_t[\rho_A(\mathbf{Q},t)]_{\omega_k}
+   \mathcal{F}_t[\rho_B(\mathbf{Q},t)]_{\omega_k}^{*}.
+
+The probe-weighted coherent total is reconstructed as
+
+.. math::
+
+   S_{\mathrm{coh}}(\mathbf{Q},\omega)
+   =
+   \sum_{A,B}
+   w_A(\mathbf{Q})w_B^*(\mathbf{Q})
+   S_{AB}(\mathbf{Q},\omega).
+
+This partial matrix helps identify which atom-type pairs dominate a neutron or
+X-ray feature before applying experimental form factors or scattering lengths.
+For map-level analysis, the partial result can be sent through the same
+paper-ready map path used by total DSF, EELS, and one-phonon visibility:
+
+.. code-block:: python
+
+   from pySED.scattering_workflow import compute_partial_dsf_workflow
+
+   result = compute_partial_dsf_workflow(
+       positions,
+       qpoints=experimental_qpoints,
+       primitive_cell=primitive,
+       supercell_cell=supercell,
+       dt=dt,
+       atom_types=atom_types,
+       qpoint_coordinates="cartesian",
+       q_policy="nearest",
+       species_weights={"Si": 4.1491, "O": 5.803},
+       map_component="weighted_total",
+   )
+
+To inspect one cross term rather than the weighted total, use
+``map_component="partial"` together with ``species_pair=("Si", "O")``.
+Because off-diagonal partial spectra are complex, the map converter requires a
+choice of ``complex_part="real"``, ``"imag"``, or ``"abs"``.  The default
+paper-facing weighted total remains real.
+
+The incoherent neutron contribution is estimated from the self terms,
+
+.. math::
+
+   S_{\mathrm{inc}}(\mathbf{Q},\omega)
+   \approx
+   \frac{1}{N T}
+   \sum_i
+   \sigma_i^{\mathrm{inc}}
+   \left|
+   \int_0^T
+   e^{i\mathbf{Q}\cdot\mathbf{r}_i(t)}
+   e^{-i\omega t}\,dt
+   \right|^2 .
+
+For neutron calculations, :math:`w_i` is the coherent scattering length and
+:math:`\sigma_i^{\mathrm{inc}}` is the incoherent cross section.  For X-ray
+calculations, pySED evaluates the neutral-atom Cromer-Mann form factor
+[ScatCromerMann1968]_
+
+.. math::
+
+   f_i^0(s)
+   =
+   \sum_{m=1}^{4}
+   a_{im}\exp[-b_{im}s^2] + c_i,
+   \qquad
+   s=\frac{|\mathbf{Q}|}{4\pi},
+
+so the coherent X-ray weight is
+
+.. math::
+
+   w_i(\mathbf{Q}) = f_i^0(|\mathbf{Q}|).
+
+The built-in table covers the same common elements as pySED's default neutron
+tables.  Users can override the coefficients for ions, custom tabulations, or
+anomalous terms through ``xray_form_factor_table`` or by passing fully
+user-defined ``coherent_weights``.  If an element is missing from the
+Cromer-Mann table, pySED can fall back to atomic-number weights for exploratory
+work, but such fallback should be reported explicitly in publication-quality
+X-ray comparisons.
+
+The implemented DSF is classical.  As in classical MD-based DSF workflows, the
+raw trajectory spectrum does not automatically satisfy quantum detailed
+balance.  pySED therefore provides an optional harmonic
+classical-to-quantum correction in :mod:`pySED.quantum_correction`.  With
+signed energy transfer :math:`E=\hbar\omega` and
+:math:`x=E/(k_B T)`, the correction factor is
+
+.. math::
+
+   C_{\mathrm{q}}(E,T)
+   =
+   \frac{x}{1-\exp(-x)}.
+
+The experiment-facing estimate is then
+
+.. math::
+
+   S_{\mathrm{q}}(\mathbf{Q},E)
+   \approx
+   C_{\mathrm{q}}(E,T)
+   S_{\mathrm{cl}}(\mathbf{Q},E).
+
+This signed form obeys detailed balance,
+
+.. math::
+
+   \frac{C_{\mathrm{q}}(-E,T)}
+   {C_{\mathrm{q}}(E,T)}
+   =
+   \exp[-E/(k_B T)],
+
+and has the well-defined zero-energy limit
+:math:`C_{\mathrm{q}}(0,T)=1`.  When the pySED axis is a frequency in THz,
+:mod:`pySED.quantum_correction` uses :math:`E=h\nu`; it can also convert axes
+among THz, meV, eV, and :math:`\mathrm{cm}^{-1}`.  This correction should be
+reported in any experimental comparison because it changes relative intensities
+across energy, not peak positions [ScatSquires2012]_.
+
+Current Correlations
+--------------------
+
+The microscopic current density is
+
+.. math::
+
+   \mathbf{j}_w(\mathbf{Q},t)
+   =
+   \sum_i
+   w_i
+   \mathbf{v}_i(t)
+   \exp[i\mathbf{Q}\cdot\mathbf{r}_i(t)].
+
+With :math:`\hat{\mathbf{Q}}=\mathbf{Q}/|\mathbf{Q}|`, the longitudinal current
+is
+
+.. math::
+
+   j_L(\mathbf{Q},t)
+   =
+   \hat{\mathbf{Q}}\cdot\mathbf{j}_w(\mathbf{Q},t),
+
+and the transverse current is
+
+.. math::
+
+   \mathbf{j}_T(\mathbf{Q},t)
+   =
+   \mathbf{j}_w(\mathbf{Q},t)
+   -
+   j_L(\mathbf{Q},t)\hat{\mathbf{Q}}.
+
+The frequency-domain longitudinal and transverse current spectra are useful for
+separating longitudinal acoustic/optic features from transverse motion.  In the
+continuum relation,
+
+.. math::
+
+   \omega^2 S(\mathbf{Q},\omega)
+   =
+   Q^2 C_L(\mathbf{Q},\omega),
+
+so current spectra can make dispersive modes clearer when density spectra have
+strong elastic backgrounds [ScatDynasor2025]_.
+
+The production current estimator follows the same block-average convention as
+the DSF estimator.  :func:`pySED.dsf.compute_current_correlations` returns
+``longitudinal_sem`` and ``transverse_sem`` when multiple blocks are used.  For
+experiment-facing maps, use
+:func:`pySED.scattering_workflow.compute_current_correlation_workflow`:
+
+.. code-block:: python
+
+   from pySED.scattering_workflow import compute_current_correlation_workflow
+
+   result = compute_current_correlation_workflow(
+       positions,
+       velocities,
+       qpoints=experimental_qpoints,
+       primitive_cell=primitive,
+       supercell_cell=supercell,
+       dt=dt,
+       qpoint_coordinates="cartesian",
+       q_policy="nearest",
+       map_component="longitudinal",
+       num_blocks=8,
+   )
+
+The returned ``result.scattering_map`` can be broadened, normalized, and
+compared to an experimental map using the same
+:mod:`pySED.compare_experiment` path as total DSF and q-EELS.  This is useful
+when the density DSF has a strong elastic line but the longitudinal current
+spectrum exposes the inelastic branch more clearly.
+
+Mode-Resolved INS/IXS Visibility
+--------------------------------
+
+The correlation-function DSF gives the trajectory spectrum
+:math:`S(\mathbf{Q},\omega)`.  To explain which phonon branches are visible in
+coherent neutron or X-ray scattering, pySED also provides the harmonic
+one-phonon mode visibility in :mod:`pySED.mode_visibility`.  This is an
+interpretation layer built from eigenvectors; it does not replace the
+finite-temperature MD correlation spectrum.
+
+For a reduced first-BZ wave vector :math:`\mathbf{q}`, reciprocal vector
+:math:`\mathbf{G}`, and experimental vector
+:math:`\mathbf{Q}=\mathbf{q}+\mathbf{G}`, the elementary contribution from
+basis atom :math:`b` and Cartesian direction :math:`\alpha` is
+
+.. math::
+
+   A_{b\alpha,\nu}^{p}(\mathbf{Q})
+   =
+   w_b^{p}(\mathbf{Q})
+   \frac{Q_\alpha e_{b\alpha,\nu}(\mathbf{q})}
+   {\sqrt{m_b}}
+   \exp[i\mathbf{Q}\cdot\boldsymbol{\tau}_b],
+
+where :math:`p` labels the probe.  For coherent neutron scattering
+:math:`w_b^{p}` is the coherent scattering length.  For X-ray scattering it is
+the q-dependent atomic form factor :math:`f_b^0(\mathbf{Q})`.  pySED then forms
+
+.. math::
+
+   I_{\nu}^{p}(\mathbf{Q})
+   =
+   \left|
+   \sum_{b,\alpha}
+   A_{b\alpha,\nu}^{p}(\mathbf{Q})
+   \right|^2.
+
+When desired, the common harmonic one-phonon prefactor can be included as
+:math:`I_\nu \rightarrow I_\nu/\omega_{\mathbf{q}\nu}` by using
+``frequency_power=-1``.  The default is ``frequency_power=0`` so users first see
+the pure polarization, mass, form-factor, and basis-interference visibility.
+
+As in the EELS diagnostic, pySED stores the complex amplitude before the final
+squared magnitude.  It reports atom-grouped amplitudes
+:math:`A_{b,\nu}=\sum_\alpha A_{b\alpha,\nu}` and direction-grouped amplitudes
+:math:`A_{\alpha,\nu}=\sum_b A_{b\alpha,\nu}`.  The atom interference residual
+
+.. math::
+
+   I_\nu^{\mathrm{interf}}
+   =
+   |A_\nu|^2
+   -
+   \sum_b |A_{b,\nu}|^2
+
+identifies constructive interference when positive and extinction when
+negative.  This is the branch-level explanation layer for deciding whether a
+mode that is present in SED is hidden in INS/IXS by
+:math:`\mathbf{Q}\cdot\mathbf{e}`, a weak probe weight, mass weighting, or
+basis interference.
+
+For paper-ready branch labels, :mod:`pySED.visibility_diagnostics` evaluates
+the same quantities as normalized diagnostic scores.  In addition to
+:math:`I_\nu^{\mathrm{interf}}`, it records the Cartesian-direction residual
+
+.. math::
+
+   I_\nu^{\mathrm{dir\ interf}}
+   =
+   |A_\nu|^2
+   -
+   \sum_\alpha |A_{\alpha,\nu}|^2,
+
+and the normalized fractions
+
+.. math::
+
+   \eta_\nu^{\mathrm{basis}}
+   =
+   \frac{I_\nu^{\mathrm{interf}}}
+        {\sum_b |A_{b,\nu}|^2},
+   \qquad
+   \eta_\nu^{\mathrm{dir}}
+   =
+   \frac{I_\nu^{\mathrm{dir\ interf}}}
+        {\sum_\alpha |A_{\alpha,\nu}|^2}.
+
+Values near :math:`-1` indicate near-complete extinction by destructive
+interference.  The diagnostic table also stores the dominant atom, dominant
+Cartesian direction, relative branch visibility at each :math:`(q,G)`, and any
+finite-size q-mapping error from :mod:`pySED.q_advisor`.
+
+.. code-block:: python
+
+   from pySED.visibility_diagnostics import diagnose_mode_visibility
+
+   diagnostics = diagnose_mode_visibility(
+       result.visibility,
+       q_advice=result.q_advice,
+       atom_labels=atom_types,
+   )
+   diagnostics.write_csv("one_phonon_visibility_diagnostics.csv", include_all=False)
+
+The energy-resolved coherent one-phonon map is obtained by combining this
+visibility with a branch-resolved spectral function,
+
+.. math::
+
+   I_{p}(\mathbf{Q},\omega)
+   =
+   \sum_\nu
+   I_{\nu}^{p}(\mathbf{Q})
+   A_\nu(\mathbf{q},\omega).
+
+As for EELS, :math:`A_\nu` can be a harmonic broadened line shape around the
+phonon frequency, or the finite-temperature branch SED
+:math:`\Phi_\nu(\mathbf{q},\omega)` from :mod:`pySED.eigen_sed`.  The latter is
+implemented by
+:func:`pySED.mode_visibility.build_one_phonon_map_from_mode_spectra` and the
+high-level workflow
+:func:`pySED.scattering_workflow.compute_one_phonon_workflow`:
+
+.. code-block:: python
+
+   from pySED.scattering_workflow import compute_one_phonon_workflow
+
+   result = compute_one_phonon_workflow(
+       velocities,
+       unitcell_vectors,
+       basis_index,
+       masses,
+       primitive_cell,
+       supercell_cell,
+       phonopy_eigenvectors,
+       basis_positions_reduced,
+       g_vectors_reduced,
+       dt,
+       atom_types=atom_types,
+       experiment="xray",      # or "neutron"
+       frequency_power=-1,
+   )
+
+The returned ``result.visibility`` gives the mode-level explanation, while
+``result.scattering_map`` can be passed directly to the experimental comparison
+and plotting utilities.
+
+For an experimental extended-zone INS/IXS path, use the q-plan wrapper:
+
+.. code-block:: python
+
+   from pySED.scattering_workflow import compute_one_phonon_workflow_from_q_path
+
+   result = compute_one_phonon_workflow_from_q_path(
+       velocities=velocities,
+       unitcell_vectors=unitcell_vectors,
+       basis_index=basis_index,
+       masses=masses,
+       primitive_cell=primitive_cell,
+       supercell_cell=md_supercell,
+       eigenvectors=phonopy_eigenvectors,
+       basis_positions_reduced=basis_positions_reduced,
+       experimental_qpoints=experimental_Q_cartesian,
+       dt=dt,
+       qpoint_coordinates="cartesian",
+       q_policy="nearest",
+       max_error_cartesian=0.02,
+       atom_types=atom_types,
+       experiment="xray",      # or "neutron"
+       frequency_power=-1,
+   )
+
+This follows the same :math:`Q=q+G` rule as q-EELS: phonopy eigenvectors and
+eigen-SED are evaluated at ``result.q_plan.qpoints_reduced``, while
+``result.q_plan.g_vectors_reduced`` is retained in the one-phonon scattering
+visibility.
+
+Eigenvector-Resolved SED
+------------------------
+
+The existing pySED production workflow uses the eigenvector-free SED formula
+described in the main theory chapter and in the SED literature
+[ScatThomas2010]_.  For branch-level interpretation, :mod:`pySED.eigen_sed`
+adds a phonopy eigenvector projection.  For primitive-cell basis atom
+:math:`b`, repeated cell :math:`l`, and Cartesian direction :math:`\alpha`,
+
+.. math::
+
+   \dot{Q}_{\mathbf{q}\nu}(t)
+   =
+   \sum_{l,b,\alpha}
+   \sqrt{m_b}\,
+   v_{lb\alpha}(t)
+   e^*_{b\alpha}(\mathbf{q},\nu)
+   \exp[i\mathbf{q}\cdot\mathbf{R}_l].
+
+The branch-resolved SED is
+
+.. math::
+
+   \Phi_{\nu}(\mathbf{q},\omega)
+   =
+   \left|
+   \mathcal{F}_t[
+   \dot{Q}_{\mathbf{q}\nu}(t)]
+   \right|^2 .
+
+Even when eigenvectors are read from phonopy, the q points must still satisfy
+the finite MD supercell condition
+
+.. math::
+
+   \mathbf{q}_{\mathrm{red}}\mathbf{P}^{T} \in \mathbb{Z}^3.
+
+Phonopy can compute eigenvectors at arbitrary reciprocal-space points because
+it evaluates a force-constant dynamical matrix.  MD SED cannot use arbitrary
+q points in the same way because the trajectory is finite and periodic.  The
+reasonable workflow is therefore:
+
+1. choose experimental or high-symmetry q points,
+2. use :mod:`pySED.q_advisor` to keep or map them to commensurate q points,
+3. ask phonopy for eigenvectors at exactly those commensurate q points,
+4. project the MD velocities with :mod:`pySED.eigen_sed`, and
+5. compare branch intensities with DSF/EELS visibility.
+
+This resolves the practical question: eigenvectors do not remove the
+commensurability requirement for an MD trajectory.  They add branch resolution
+after a valid finite-supercell q point has been selected.
+
+Kinematic q-EELS Visibility
+---------------------------
+
+Momentum-resolved vibrational EELS measures an electron-scattering-weighted
+phonon spectrum.  The first pySED layer is a kinematic one-phonon visibility
+model in the extended Brillouin zone.
+
+Experimental q-EELS axes are often calibrated in detector angle rather than
+direct reciprocal-space units.  :mod:`pySED.electron_kinematics` converts this
+geometry into Cartesian momentum transfer before the q-advisor step.  For an
+incident kinetic energy :math:`E_0`, the relativistic electron momentum is
+
+.. math::
+
+   pc
+   =
+   \sqrt{E_0(E_0+2m_ec^2)},
+   \qquad
+   \lambda
+   =
+   \frac{hc}{pc},
+   \qquad
+   k_0
+   =
+   \frac{2\pi}{\lambda}.
+
+For small scattering angles :math:`(\theta_x,\theta_y)` and energy loss
+:math:`\Delta E`, pySED uses the q-EELS calibration [ScatEgerton2011]_
+
+.. math::
+
+   Q_x \simeq k_0\theta_x,
+   \qquad
+   Q_y \simeq k_0\theta_y,
+   \qquad
+   Q_z \simeq \frac{\Delta E}{\hbar v}
+   =
+   \frac{\Delta E}{\hbar c\beta},
+
+where :math:`\beta=v/c`.  For vibrational losses the longitudinal term is
+usually much smaller than the transverse detector momentum, so the
+line-scan helper leaves it off by default:
+
+.. code-block:: python
+
+   from pySED.electron_kinematics import eels_qpoints_from_angle_axis
+
+   experimental_Q_cartesian = eels_qpoints_from_angle_axis(
+       angle_axis_mrad,
+       beam_energy_ev=200_000.0,
+       direction=(1.0, 0.0),
+       angle_unit="mrad",
+       include_longitudinal=False,
+   )
+
+The resulting ``experimental_Q_cartesian`` array can be passed directly to
+:class:`pySED.q_advisor.QAdvisor` or to
+``compute_eels_workflow_from_q_path(..., qpoint_coordinates="cartesian")``.
+The same small-angle conversion can translate an experimental angular
+resolution into the momentum-resolution width used for map comparison:
+
+.. code-block:: python
+
+   from pySED.electron_kinematics import angular_resolution_to_q_sigma
+
+   sigma_q = angular_resolution_to_q_sigma(
+       sigma_angle=2.0,
+       beam_energy_ev=200_000.0,
+       angle_unit="mrad",
+   )
+
+   comparison = prepare_map_comparison(
+       simulated_map,
+       experimental_map,
+       sigma_q=sigma_q,
+       sigma_energy=3.0,
+       energy_unit="meV",
+   )
+
+For a complete MD-to-q-EELS calculation, pySED also provides the one-call
+workflow:
+
+.. code-block:: python
+
+   from pySED.scattering_workflow import compute_eels_workflow_from_angle_axis
+
+   result = compute_eels_workflow_from_angle_axis(
+       velocities=velocities,
+       unitcell_vectors=unitcell_vectors,
+       basis_index=basis_index,
+       masses=masses,
+       primitive_cell=primitive_cell,
+       supercell_cell=md_supercell,
+       eigenvectors=phonopy_eigenvectors,
+       basis_positions_reduced=basis_positions_reduced,
+       angle_axis=angle_axis_mrad,
+       beam_energy_ev=200_000.0,
+       direction=(1.0, 0.0),
+       angle_unit="mrad",
+       dt=dt,
+       q_policy="nearest",
+       max_error_cartesian=0.02,
+       atom_types=atom_types,
+       electron_form_factor_model="mott-bethe",
+   )
+
+For the scattering visibility itself, given
+
+.. math::
+
+   \mathbf{Q} = \mathbf{q} + \mathbf{G},
+
+where :math:`\mathbf{q}` is folded into the first Brillouin zone and
+:math:`\mathbf{G}` is a reciprocal lattice vector, pySED estimates the
+branch-resolved visibility as
+
+.. math::
+
+   I_{\nu}(\mathbf{Q})
+   \propto
+   \left|
+   \sum_b
+   f_b^{e}(\mathbf{Q})
+   \frac{\mathbf{Q}\cdot
+   \mathbf{e}_{b\nu}(\mathbf{q})}
+   {\sqrt{m_b}}
+   \exp[i\mathbf{Q}\cdot\boldsymbol{\tau}_b]
+   \right|^2 .
+
+This expression contains the main terms needed for interpreting
+momentum-resolved EELS selection and interference:
+
+- :math:`\mathbf{Q}\cdot\mathbf{e}_{b\nu}` gives polarization selection,
+- :math:`\exp[i\mathbf{Q}\cdot\boldsymbol{\tau}_b]` gives basis interference,
+- :math:`f_b^e(\mathbf{Q})` gives electron probe weighting, and
+- :math:`\mathbf{Q}=\mathbf{q}+\mathbf{G}` exposes higher-Brillouin-zone
+  extinction and enhancement.
+
+By default pySED keeps :math:`f_b^e(\mathbf{Q})=1` to preserve the earlier
+unit-weight visibility.  For a first quantitative electron-probe estimate,
+``electron_form_factor_model="mott-bethe"`` uses the neutral-atom Mott-Bethe
+relation [ScatMottBethe]_ [ScatPeng1996]_
+
+.. math::
+
+   f_b^e(\mathbf{Q})
+   =
+   C_e
+   \frac{Z_b-f_b^X(|\mathbf{Q}|)}
+        {|\mathbf{Q}|^2},
+
+where :math:`f_b^X` is the Cromer-Mann X-ray form factor
+[ScatCromerMann1968]_ and :math:`Z_b` is the atomic number.  The current
+kinematic EELS implementation drops the constant :math:`C_e` because relative
+intensities are sufficient for branch visibility, extinction, and map
+comparison after normalization.  For :math:`|\mathbf{Q}|\rightarrow0`, pySED
+uses the analytic derivative of the Cromer-Mann expansion,
+
+.. math::
+
+   \lim_{Q\rightarrow0}
+   \frac{Z-f^X(Q)}{Q^2}
+   =
+   \frac{1}{16\pi^2}
+   \sum_i a_i b_i,
+
+provided the neutral-atom coefficients satisfy
+:math:`f^X(0)=\sum_i a_i+c\simeq Z`.  Users can still pass
+``electron_form_factors`` explicitly when they have a dedicated electron
+scattering table, ionic form factors, or a later multislice/TACAW model.
+
+For a real q-EELS line scan, the measured points are usually a pairwise path
+:math:`\mathbf{Q}_i`, not the Cartesian product of all folded q points and all
+reciprocal-lattice vectors.  pySED therefore provides an explicit extended-zone
+planner:
+
+.. code-block:: python
+
+   from pySED.q_advisor import QAdvisor
+
+   advisor = QAdvisor(primitive_cell, md_supercell)
+   q_plan = advisor.plan_extended_zone_q_path(
+       experimental_Q_cartesian,
+       coordinates="cartesian",
+       q_policy="nearest",
+       max_error_cartesian=0.02,
+   )
+
+   q_plan.write_phonopy_qpoints("phonopy_qpoints.dat")
+
+The plan stores
+
+.. math::
+
+   \mathbf{Q}_i^{\mathrm{used}}
+   =
+   \mathbf{q}_i^{\mathrm{folded}}
+   +
+   \mathbf{G}_i,
+
+where :math:`\mathbf{Q}_i^{\mathrm{used}}` is commensurate with the MD
+supercell, :math:`\mathbf{q}_i^{\mathrm{folded}}` is the q point that should be
+used for phonopy eigenvectors and eigen-SED, and :math:`\mathbf{G}_i` is the
+integer extended-zone vector.  Use
+:func:`pySED.eels.compute_mode_visibility_for_q_path`, or
+``compute_eels_workflow(..., pairwise_g_vectors=True)``, when
+``qpoints_reduced`` and ``g_vectors_reduced`` have this one-to-one path
+meaning.  The default :func:`pySED.eels.compute_mode_visibility` behavior still
+computes the full q-by-G product, which is useful for making extended-zone maps
+over several Brillouin zones.
+
+For production scripts, the recommended single entry point is
+:func:`pySED.scattering_workflow.compute_eels_workflow_from_q_path`:
+
+.. code-block:: python
+
+   from pySED.scattering_workflow import compute_eels_workflow_from_q_path
+
+   result = compute_eels_workflow_from_q_path(
+       velocities=velocities,
+       unitcell_vectors=unitcell_vectors,
+       basis_index=basis_index,
+       masses=masses,
+       primitive_cell=primitive_cell,
+       supercell_cell=md_supercell,
+       eigenvectors=phonopy_eigenvectors,
+       basis_positions_reduced=basis_positions_reduced,
+       experimental_qpoints=experimental_Q_cartesian,
+       dt=dt,
+       qpoint_coordinates="cartesian",
+       q_policy="nearest",
+       max_error_cartesian=0.02,
+       atom_types=atom_types,
+       electron_form_factor_model="mott-bethe",
+   )
+
+This wrapper returns ``result.q_plan`` together with ``result.eigen_sed``,
+``result.visibility``, ``result.eels_map``, and ``result.scattering_map``.  It
+also validates that the phonopy eigenvectors are supplied at the folded
+commensurate q points from ``result.q_plan.qpoints_reduced``.  In practice this
+prevents a common mistake: using the extended-zone experimental
+:math:`\mathbf{Q}` as the phonopy q point instead of using the folded
+:math:`\mathbf{q}` and retaining :math:`\mathbf{G}` only in the scattering
+visibility.
+
+For mode-level interpretation,
+:func:`pySED.eels.compute_mode_visibility_decomposition` keeps the complex
+amplitude before the final squared magnitude.  The elementary contribution is
+
+.. math::
+
+   A_{b\alpha,\nu}(\mathbf{Q})
+   =
+   f_b^e(\mathbf{Q})
+   \frac{Q_\alpha e_{b\alpha,\nu}(\mathbf{q})}
+   {\sqrt{m_b}}
+   \exp[i\mathbf{Q}\cdot\boldsymbol{\tau}_b].
+
+The total mode amplitude and visibility are
+
+.. math::
+
+   A_\nu(\mathbf{Q})
+   =
+   \sum_{b,\alpha}
+   A_{b\alpha,\nu}(\mathbf{Q}),
+   \qquad
+   I_\nu(\mathbf{Q})
+   =
+   |A_\nu(\mathbf{Q})|^2.
+
+pySED also reports coherent diagnostic amplitudes grouped by atom and by
+Cartesian direction,
+
+.. math::
+
+   A_{b,\nu}=\sum_\alpha A_{b\alpha,\nu},
+   \qquad
+   A_{\alpha,\nu}=\sum_b A_{b\alpha,\nu}.
+
+The diagnostic quantities :math:`|A_{b,\nu}|^2` and
+:math:`|A_{\alpha,\nu}|^2` identify which basis atoms and displacement
+directions are visible before interference.  They are not additive intensities:
+
+.. math::
+
+   |A_\nu|^2
+   \ne
+   \sum_b |A_{b,\nu}|^2
+
+when basis interference is present.  pySED therefore records the atom
+interference residual
+
+.. math::
+
+   I_\nu^{\mathrm{interf}}
+   =
+   |A_\nu|^2
+   -
+   \sum_b |A_{b,\nu}|^2,
+
+which is positive for constructive interference and negative for extinction.
+This is the practical diagnostic for deciding whether a branch disappears
+because of polarization selection, a weak form factor, or destructive basis
+interference.
+
+The same :mod:`pySED.visibility_diagnostics` helper can be applied to the EELS
+decomposition object.  For an EELS workflow, use
+``compute_mode_visibility_decomposition`` when calling the low-level API, or
+pass ``result.visibility`` from a workflow when it already contains atom and
+direction amplitudes.  The resulting CSV table gives a compact branch-by-branch
+classification: ``visible``, ``basis_interference``,
+``polarization_or_zero_weight``, ``cartesian_interference``,
+``finite_size_q_mapping``, or ``weak_visibility``.  These labels are diagnostic
+metadata; the simulated intensity still comes from the coherent visibility
+:math:`I_\nu(\mathbf{Q})`.
+
+The energy-resolved kinematic map is then
+
+.. math::
+
+   I_{\mathrm{EELS}}(\mathbf{Q},\omega)
+   =
+   \sum_{\nu}
+   I_{\nu}(\mathbf{Q})
+   A_{\nu}(\mathbf{q},\omega),
+
+where :math:`A_{\nu}` can be supplied in two ways.  For a harmonic reference,
+:func:`pySED.eels.build_eels_map` represents :math:`A_{\nu}` by a Gaussian or
+Lorentzian broadening around the phonon frequency.  For a finite-temperature MD
+calculation, :func:`pySED.eels.build_eels_map_from_mode_spectra` can consume the
+branch-resolved spectral function from :mod:`pySED.eigen_sed`,
+
+.. math::
+
+   A_{\nu}(\mathbf{q},\omega)
+   \equiv
+   \Phi_{\nu}(\mathbf{q},\omega),
+
+and evaluate the same visibility-weighted sum directly.  This is the preferred
+pySED-native route for a MD-to-EELS comparison because anharmonic peak shifts
+and linewidths are inherited from the trajectory rather than imposed by an
+external broadening model.
+
+The same branch spectra can be used to make energy-resolved diagnostic maps:
+
+.. math::
+
+   I_b(\mathbf{Q},\omega)
+   =
+   \sum_\nu
+   |A_{b,\nu}(\mathbf{Q})|^2
+   A_\nu(\mathbf{q},\omega),
+   \qquad
+   I_{\mathrm{interf}}(\mathbf{Q},\omega)
+   =
+   \sum_\nu
+   I_{\nu}^{\mathrm{interf}}(\mathbf{Q})
+   A_\nu(\mathbf{q},\omega).
+
+They obey
+
+.. math::
+
+   I_{\mathrm{EELS}}(\mathbf{Q},\omega)
+   =
+   \sum_b I_b(\mathbf{Q},\omega)
+   +
+   I_{\mathrm{interf}}(\mathbf{Q},\omega),
+
+while the Cartesian-direction maps remain diagnostic projections rather than an
+additive partition of the total intensity.  Use
+:func:`pySED.eels.build_eels_decomposition_map_from_mode_spectra` for EELS and
+:func:`pySED.mode_visibility.build_one_phonon_decomposition_map_from_mode_spectra`
+for coherent neutron/X-ray one-phonon maps.
+
+A later PySlice-like layer can replace this kinematic intensity with a
+pySED-native multislice or TACAW electron propagation model [ScatPySlice2026]_.
+The current layer is still valuable because it already explains many missing
+or enhanced branches through polarization, basis interference, form factors,
+and finite-size q sampling.
+
+Experiment Comparison
+---------------------
+
+The :mod:`pySED.compare_experiment` module provides a paper-ready comparison
+path:
+
+1. load an experimental intensity map with calibrated q and energy axes,
+2. optionally convert simulation energy axes to the experimental unit,
+3. optionally apply the harmonic quantum detailed-balance correction,
+4. broaden simulated spectra with the experimental energy resolution,
+5. convolve or smooth along q to model momentum resolution,
+6. normalize simulated and experimental maps consistently,
+7. compute residual maps and scalar residual metrics,
+8. extract line cuts at selected q or energy values, and
+9. track simulated and experimental peak positions.
+
+Experimental figures can be imported directly when only an image is available.
+For a calibrated q-EELS image, use
+:func:`pySED.compare_experiment.load_scattering_map_image` to convert pixels
+into a :class:`pySED.compare_experiment.ScatteringMap`:
+
+.. code-block:: python
+
+   from pySED.compare_experiment import load_scattering_map_image
+
+   experimental_map = load_scattering_map_image(
+       "experimental_qeels.png",
+       q_range=(-0.6, 0.6),       # left and right image limits
+       energy_range=(0.0, 180.0), # bottom and top image limits
+       crop=(40, 420, 30, 730),   # row_start, row_stop, col_start, col_stop
+       origin="upper",
+       invert=False,
+       normalization="max",
+   )
+
+The image columns are mapped to the q axis and the image rows are mapped to the
+energy axis.  ``origin="upper"`` is appropriate for ordinary image files where
+row zero is the top of the image; pySED flips the pixel array so the returned
+energy axis increases from ``energy_range[0]`` to ``energy_range[1]``.  If the
+experimental map uses dark intensity on a bright background, set ``invert=True``.
+
+For direct figure export, :mod:`pySED.scattering_plot` can render individual
+maps, overlaid line cuts, or a combined simulated/experimental/residual figure.
+The combined figure uses the normalized arrays stored in
+:class:`pySED.compare_experiment.MapComparison`, so the plotted residual is
+exactly the quantity used for RMSE, MAE, and correlation:
+
+.. code-block:: python
+
+   from pySED.compare_experiment import prepare_map_comparison
+   from pySED.scattering_plot import plot_map_comparison
+
+   comparison = prepare_map_comparison(
+       simulated_map,
+       experimental_map,
+       sigma_q=0.02,
+       sigma_energy=3.0,
+       normalization="max",
+       quantum_temperature=300.0,
+       energy_unit="meV",
+   )
+   fig = plot_map_comparison(
+       comparison,
+       q_label="Q path (1/Angstrom)",
+       energy_label="Energy loss (meV)",
+       save_path="pysed_eels_comparison.png",
+   )
+
+The same comparison object can be exported as manuscript-ready tables:
+
+.. code-block:: python
+
+   from pySED.compare_experiment import write_map_comparison_report
+
+   paths = write_map_comparison_report(
+       comparison,
+       output_dir="paper_eels_comparison",
+       prefix="figure_3",
+       linecut_q_indices=[10, 25],
+       linecut_energy_indices=[40],
+   )
+
+This writes ``figure_3_summary.json`` with RMSE, MAE, correlation, axis ranges,
+and metadata; ``figure_3_residual.csv`` with flattened
+:math:`R(q,\omega)` values; and ``figure_3_peaks.csv`` with the simulated and
+experimental peak energy at each q point.  When line-cut indices are supplied,
+it also writes ``figure_3_linecuts.csv``.  Fixed-q rows report intensity as a
+function of energy, while fixed-energy rows report intensity along the q path.
+These exported tables are intended to accompany the plotted residual map and
+line cuts in a reproducible paper workflow.
+
+For a complete workflow result, :mod:`pySED.scattering_export` can write a
+single reproducibility bundle:
+
+.. code-block:: python
+
+   from pySED.scattering_export import write_scattering_workflow_bundle
+
+   written = write_scattering_workflow_bundle(
+       result,
+       output_dir="figure_3_bundle",
+       prefix="qeels",
+       atom_labels=atom_types,
+       linecut_q_indices=[10, 25],
+       linecut_energy_indices=[40],
+   )
+
+For q-EELS and one-phonon workflows this bundle includes the extended-zone
+``q_plan`` CSV, folded ``phonopy_qpoints.dat``, branch visibility diagnostics,
+the simulated scattering map, and any experimental comparison summary,
+residual, peak, and line-cut tables.  For DSF workflows it exports the q-advisor
+table and scattering map.  This is the recommended archive format for
+paper-figure provenance because the finite-size q mapping and the residual
+metrics are stored beside the simulated intensity.
+
+For a two-dimensional q-energy map, the high-level workflow is represented by
+:class:`pySED.compare_experiment.ScatteringMap` and
+:func:`pySED.compare_experiment.prepare_map_comparison`.  If the simulated map
+has axes :math:`(q_s,\omega_s)` and the experimental map has axes
+:math:`(q_e,\omega_e)`, pySED first interpolates
+
+.. math::
+
+   I_s(q_s,\omega_s)
+   \rightarrow
+   I_s(q_e,\omega_e),
+
+then can apply the optional detailed-balance correction
+:math:`C_{\mathrm{q}}(E,T)`.  The experimental resolution is then modeled as a
+Gaussian convolution,
+
+.. math::
+
+   \tilde{I}_s(q,\omega)
+   =
+   G_q(\sigma_q) * G_\omega(\sigma_\omega) *
+   I_s(q,\omega),
+
+where :math:`\sigma_q` and :math:`\sigma_\omega` are supplied in the physical
+axis units rather than pixel units.  The residual map is
+
+.. math::
+
+   R(q,\omega)
+   =
+   N[\tilde{I}_s(q,\omega)]
+   -
+   N[I_{\mathrm{exp}}(q,\omega)],
+
+where :math:`N[\cdot]` is the selected normalization, for example max, area, or
+z-score normalization.  pySED reports RMSE, MAE, and the Pearson correlation of
+the aligned maps.
+
+The intended manuscript-level workflow is therefore:
+
+.. math::
+
+   \mathrm{MD}
+   \rightarrow
+   \mathrm{commensurate\ } \mathbf{Q}
+   \rightarrow
+   \mathrm{SED/DSF/EELS}
+   \rightarrow
+   \mathrm{resolution\ convolution}
+   \rightarrow
+   \mathrm{experimental\ comparison}.
+
+Comparison With dynasor and pynamic
+-----------------------------------
+
+The recommended interpretation is:
+
+- dynasor is the main theoretical and validation reference.  It formalizes the
+  DSF through Van Hove and intermediate scattering functions, supports partial
+  correlations, probe-specific weights, and mode projection.
+- pynamic-structure-factor is a practical implementation reference for the
+  direct selected-Q calculation of inelastic neutron and X-ray
+  :math:`S(\mathbf{Q},\omega)`.
+- pySED should combine these strengths: dynasor-style theory, pynamic-style
+  selected-Q efficiency, and pySED-specific commensurate q selection, SED
+  integration, EELS extended-zone visibility, and experiment comparison.
+
+This is why the current implementation uses
+
+.. math::
+
+   F_{AB}(\mathbf{Q},t)
+   \xrightarrow{\mathcal{F}_t}
+   S_{AB}(\mathbf{Q},\omega)
+
+as the paper-facing theory, while the code evaluates
+
+.. math::
+
+   \rho_w(\mathbf{Q},t)
+   \xrightarrow{\mathrm{FFT}_t}
+   S_w(\mathbf{Q},\omega)
+
+as the efficient estimator.
+
+Validation Targets
+------------------
+
+The current unit tests cover array shapes, non-negative spectra, q-point
+validation, nearest-q mapping, EELS visibility, eigenvector SED, and experiment
+map utilities.  The module :mod:`pySED.validation` and the script
+``benchmarks/dsf_reference_validation.py`` provide a lightweight developer
+entry point for checking the production direct estimator against the explicit
+correlation reference estimator:
+
+.. code-block:: powershell
+
+   python benchmarks\dsf_reference_validation.py `
+       --json validation_report.json `
+       --export-case validation_case.npz
+
+The JSON report records Python, NumPy, and pySED versions, the internal
+direct-vs-correlation error, and whether optional external packages such as
+dynasor or pynamic-structure-factor are importable.  The exported ``.npz`` file
+contains the deterministic positions, Q points, q-dependent coherent weights,
+time step, block count, and pySED reference spectra.  This makes external
+cross-validation reproducible: dynasor or pynamic should be run on the same
+trajectory, Q points, weights, time window, block convention, and normalization
+before comparing the spectra.
+
+The external comparison path is intentionally file-based so that dynasor or
+pynamic can be run in a separate environment without becoming pySED runtime
+dependencies.  A reproducible comparison has three steps:
+
+.. code-block:: powershell
+
+   python benchmarks\dsf_reference_validation.py `
+       --export-case validation_case.npz
+
+Run the external package on ``validation_case.npz`` using the same
+``positions``, ``qpoints_cartesian``, ``coherent_weights``, ``dt``, and
+``num_blocks``.  Save the external spectrum to an ``.npz`` file with a spectrum
+key such as ``coherent`` and a frequency key such as ``frequencies_thz``.  The
+frequency unit must match pySED's THz axis; convert angular-frequency outputs
+before writing the comparison file.
+
+.. code-block:: powershell
+
+   python benchmarks\dsf_reference_validation.py `
+       --compare-reference external_dsf.npz `
+       --reference-key coherent `
+       --reference-frequency-key frequencies_thz `
+       --candidate-component coherent `
+       --normalization least_squares `
+       --comparison-json external_compare.json
+
+``--normalization least_squares`` reports the best scalar scale factor before
+computing RMSE, which is useful when two packages use different Fourier or
+probe-weight prefactors.  Use ``--normalization none`` for absolute-intensity
+checks after the conventions have been matched.
+
+The internal reference check is not a substitute for external validation.  It
+proves only the finite-time identity
+
+.. math::
+
+   \left|
+   \mathcal{F}_t[\rho_w(\mathbf{Q},t)]
+   \right|^2
+   \equiv
+   \mathcal{F}_t[
+   \langle \rho_w(\mathbf{Q},t+\tau)
+   \rho_w^*(\mathbf{Q},t)\rangle_t]
+
+under the same circular-block convention.  External validation is still needed
+to compare normalization, partial correlations, weighting conventions, and
+trajectory handling against established packages.  The remaining scientific
+validation targets are:
+
+- compare pySED DSF with dynasor for identical trajectories, Q points, weights,
+  and normalization conventions;
+- compare the direct :math:`\rho(\mathbf{Q},t)\rightarrow\mathrm{FFT}`
+  estimator with pynamic-structure-factor for identical trajectories;
+- verify that non-commensurate q points are rejected or mapped before
+  eigenvector projection;
+- validate extended-zone EELS selection and interference against q-EELS
+  examples and PySlice benchmarks; and
+- add experimental map examples with residuals, line cuts, and peak tracking.
+
+References
+----------
+
+.. [ScatVanHove1954] L. Van Hove, "Correlations in space and time and Born
+   approximation scattering in systems of interacting particles," *Physical
+   Review* **95**, 249 (1954). https://doi.org/10.1103/PhysRev.95.249
+
+.. [ScatSquires2012] G. L. Squires, *Introduction to the Theory of Thermal Neutron
+   Scattering*, Dover Publications (2012).
+
+.. [ScatThomas2010] J. A. Thomas, J. E. Turney, R. M. Iutzi, C. H. Amon, and
+   A. J. H. McGaughey, "Predicting phonon dispersion relations and lifetimes
+   from the spectral energy density," *Physical Review B* **81**, 081411
+   (2010). https://doi.org/10.1103/PhysRevB.81.081411
+
+.. [ScatCromerMann1968] D. T. Cromer and J. B. Mann, "X-ray scattering factors
+   computed from numerical Hartree-Fock wave functions," *Acta
+   Crystallographica Section A* **24**, 321-324 (1968).
+   https://doi.org/10.1107/S0567739468000550
+
+.. [ScatMottBethe] L. Pacoste, V. M. Ignat'ev, P. M. Dominiak, and X. Zou,
+   "On the structure refinement of metal complexes against 3D electron
+   diffraction data using multipolar scattering factors," *IUCrJ* **11**,
+   878-890 (2024). https://doi.org/10.1107/S2052252524006730
+
+.. [ScatPeng1996] L.-M. Peng, G. Ren, S. L. Dudarev, and M. J. Whelan,
+   "Robust parameterization of elastic and absorptive electron atomic
+   scattering factors," *Acta Crystallographica Section A* **52**, 257-276
+   (1996). https://doi.org/10.1107/S0108767395014371
+
+.. [ScatEgerton2011] R. F. Egerton, *Electron Energy-Loss Spectroscopy in the
+   Electron Microscope*, 3rd ed. (Springer, 2011).
+   https://doi.org/10.1007/978-1-4419-9583-4
+
+.. [ScatDynasor2025] E. Berger, E. Fransson, F. Eriksson, E. Lindgren,
+   G. Wahnstrom, T. H. Rod, and P. Erhart, "Dynasor 2: From simulation to
+   experiment through correlation functions," *Computer Physics
+   Communications* **316**, 109759 (2025).
+   https://doi.org/10.1016/j.cpc.2025.109759
+
+.. [ScatPynamic2025] T. C. Sterling, "pynamic-structure-factor: a python program
+   to calculate dynamic structure factors in the classical limit," manual dated
+   May 8, 2025, and source repository.
+   https://github.com/tyst3273/pynamic-structure-factor
+
+.. [ScatPySlice2026] H. Walker, "PySlice: Routine Vibrational Electron Energy Loss
+   Spectroscopy Prediction with Universal Interatomic Potentials" (2026).
+   https://github.com/h-walk/PySlice

--- a/docs/source/scattering_api.rst
+++ b/docs/source/scattering_api.rst
@@ -1,0 +1,125 @@
+Scattering API
+==============
+
+This page lists the pySED-native scattering extension APIs.  See
+:doc:`scattering` for the theory, q-point rules, and implementation rationale.
+
+Shared Kernel
+-------------
+
+.. automodule:: pySED.scattering_kernel
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Probe Weights
+-------------
+
+.. automodule:: pySED.probe_weights
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Quantum Correction
+------------------
+
+.. automodule:: pySED.quantum_correction
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Q-Point Advisor
+---------------
+
+.. automodule:: pySED.q_advisor
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Dynamic Structure Factor
+------------------------
+
+.. automodule:: pySED.dsf
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Mode Visibility
+---------------
+
+.. automodule:: pySED.mode_visibility
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Visibility Diagnostics
+----------------------
+
+.. automodule:: pySED.visibility_diagnostics
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Eigenvector SED
+---------------
+
+.. automodule:: pySED.eigen_sed
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Electron Kinematics
+-------------------
+
+.. automodule:: pySED.electron_kinematics
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Kinematic q-EELS
+----------------
+
+.. automodule:: pySED.eels
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Experiment Comparison
+---------------------
+
+.. automodule:: pySED.compare_experiment
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Scattering Plots
+----------------
+
+.. automodule:: pySED.scattering_plot
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Scattering Workflows
+--------------------
+
+.. automodule:: pySED.scattering_workflow
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Scattering Export
+-----------------
+
+.. automodule:: pySED.scattering_export
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Validation
+----------
+
+.. automodule:: pySED.validation
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/pySED/My_Parsers.py
+++ b/pySED/My_Parsers.py
@@ -19,6 +19,30 @@ def parse_float_or_fraction(token):
     except ValueError:
         return float(Fraction(token))
 
+def parse_optional_float(token):
+    value = str(token).strip('\'"').lower()
+    if value in ('none', 'null', 'nan'):
+        return None
+    return float(token)
+
+def parse_mesh_axis(tokens):
+    values = np.array([parse_float_or_fraction(token) for token in tokens], dtype=float)
+    if values.size == 1:
+        return float(values[0])
+    if values.size == 3:
+        return values
+    raise ValueError("mesh axis must be a scalar or start stop num")
+
+def parse_int_list(tokens):
+    values = [parse_float_or_fraction(token) for token in tokens]
+    integers = []
+    for value in values:
+        integer = int(round(value))
+        if not np.isclose(value, integer):
+            raise ValueError("expected integer value")
+        integers.append(integer)
+    return np.array(integers, dtype=int)
+
 class get_parse_input(object):
     def __init__(self, input_file='input_SED.in'):
 
@@ -37,7 +61,14 @@ class get_parse_input(object):
             'peak_height', 'peak_prominence', 'initial_guess_hwhm',
             'peak_max_hwhm', 'lorentz_fit_cutoff', 'modulate_factor',
             'lorentz_fit_all_qpoint', 'with_eigs', 'plot_color', 'colorbar_min',
-            'colorbar_max', 'output_partial', 'plot_partial_SED'
+            'colorbar_max', 'output_partial', 'plot_partial_SED',
+            'scattering', 'scattering_mode', 'scattering_qpoints_option',
+            'scattering_qpoint_coordinates', 'scattering_qpoints',
+            'scattering_q_file', 'scattering_q_mesh_H', 'scattering_q_mesh_K',
+            'scattering_q_mesh_L', 'scattering_q_path_steps',
+            'scattering_q_policy', 'scattering_preserve_image',
+            'scattering_max_error_reduced', 'scattering_max_error_cartesian',
+            'scattering_report_efficiency', 'scattering_output_prefix'
         }
 
         ## ************ Control parameters ************
@@ -93,8 +124,29 @@ class get_parse_input(object):
         ## ********** eigenvector from phonopy for further development
         self.with_eigs = None
 
+        ## ********** experiment-facing scattering/q-advisor controls
+        self.scattering = False
+        self.scattering_mode = 'q_advisor'
+        self.scattering_qpoints_option = 'path'
+        self.scattering_qpoint_coordinates = 'reduced'
+        self.scattering_qpoints = None
+        self.scattering_q_file = None
+        self.scattering_q_mesh_H = 0.0
+        self.scattering_q_mesh_K = 0.0
+        self.scattering_q_mesh_L = 0.0
+        self.scattering_q_path_steps = None
+        self.scattering_q_policy = 'strict'
+        self.scattering_preserve_image = True
+        self.scattering_max_error_reduced = None
+        self.scattering_max_error_cartesian = None
+        self.scattering_report_efficiency = True
+        self.scattering_output_prefix = None
+
         self._pending_q_path_tokens = None
-        input_txt = open(self.input_file, 'r').readlines()
+        try:
+            input_txt = open(self.input_file, 'r', encoding='utf-8-sig').readlines()
+        except UnicodeDecodeError:
+            input_txt = open(self.input_file, 'r').readlines()
 
         for line in input_txt:
             # strip inline comments and skip blank/comment lines
@@ -196,6 +248,107 @@ class get_parse_input(object):
 
                 except:
                     print_error('q_path', input_file)
+
+            # Experiment-facing scattering controls
+            elif txt[0] == 'scattering':
+                try:
+                    self.scattering = bool(int(txt[txt.index('=') + 1]))
+                except:
+                    print_error('scattering', input_file)
+
+            elif txt[0] == 'scattering_mode':
+                try:
+                    self.scattering_mode = str(txt[txt.index('=') + 1].strip('\'"')).lower()
+                except:
+                    print_error('scattering_mode', input_file)
+
+            elif txt[0] == 'scattering_qpoints_option':
+                try:
+                    self.scattering_qpoints_option = str(txt[txt.index('=') + 1].strip('\'"')).lower()
+                except:
+                    print_error('scattering_qpoints_option', input_file)
+
+            elif txt[0] == 'scattering_qpoint_coordinates':
+                try:
+                    self.scattering_qpoint_coordinates = str(txt[txt.index('=') + 1].strip('\'"')).lower()
+                except:
+                    print_error('scattering_qpoint_coordinates', input_file)
+
+            elif txt[0] == 'scattering_qpoints':
+                try:
+                    tokens = txt[(txt.index('=') + 1):]
+                    if len(tokens) == 0 or len(tokens) % 3 != 0:
+                        print_error('scattering_qpoints', input_file)
+                    values = [parse_float_or_fraction(token) for token in tokens]
+                    self.scattering_qpoints = np.array(values, dtype=float).reshape(-1, 3)
+                except:
+                    print_error('scattering_qpoints', input_file)
+
+            elif txt[0] == 'scattering_q_file':
+                try:
+                    self.scattering_q_file = str(txt[txt.index('=') + 1].strip('\'"'))
+                except:
+                    print_error('scattering_q_file', input_file)
+
+            elif txt[0] == 'scattering_q_mesh_H':
+                try:
+                    self.scattering_q_mesh_H = parse_mesh_axis(txt[(txt.index('=') + 1):])
+                except:
+                    print_error('scattering_q_mesh_H', input_file)
+
+            elif txt[0] == 'scattering_q_mesh_K':
+                try:
+                    self.scattering_q_mesh_K = parse_mesh_axis(txt[(txt.index('=') + 1):])
+                except:
+                    print_error('scattering_q_mesh_K', input_file)
+
+            elif txt[0] == 'scattering_q_mesh_L':
+                try:
+                    self.scattering_q_mesh_L = parse_mesh_axis(txt[(txt.index('=') + 1):])
+                except:
+                    print_error('scattering_q_mesh_L', input_file)
+
+            elif txt[0] == 'scattering_q_path_steps':
+                try:
+                    self.scattering_q_path_steps = parse_int_list(txt[(txt.index('=') + 1):])
+                except:
+                    print_error('scattering_q_path_steps', input_file)
+
+            elif txt[0] == 'scattering_q_policy':
+                try:
+                    self.scattering_q_policy = str(txt[txt.index('=') + 1].strip('\'"')).lower()
+                except:
+                    print_error('scattering_q_policy', input_file)
+
+            elif txt[0] == 'scattering_preserve_image':
+                try:
+                    self.scattering_preserve_image = bool(int(txt[txt.index('=') + 1]))
+                except:
+                    print_error('scattering_preserve_image', input_file)
+
+            elif txt[0] == 'scattering_max_error_reduced':
+                try:
+                    self.scattering_max_error_reduced = parse_optional_float(txt[txt.index('=') + 1])
+                except:
+                    print_error('scattering_max_error_reduced', input_file)
+
+            elif txt[0] == 'scattering_max_error_cartesian':
+                try:
+                    self.scattering_max_error_cartesian = parse_optional_float(txt[txt.index('=') + 1])
+                except:
+                    print_error('scattering_max_error_cartesian', input_file)
+
+            elif txt[0] == 'scattering_report_efficiency':
+                try:
+                    self.scattering_report_efficiency = bool(int(txt[txt.index('=') + 1]))
+                except:
+                    print_error('scattering_report_efficiency', input_file)
+
+            elif txt[0] == 'scattering_output_prefix':
+                try:
+                    self.scattering_output_prefix = str(txt[txt.index('=') + 1].strip('\'"'))
+                except:
+                    print_error('scattering_output_prefix', input_file)
 
             # whether or not to build hdf5 database
             elif txt[0] == 'compress':

--- a/pySED/__init__.py
+++ b/pySED/__init__.py
@@ -1,3 +1,119 @@
 """SED calculation code: pySED."""
 
 from pySED.version import __version__  # noqa F401
+from pySED.compare_experiment import MapComparison, ScatteringMap
+from pySED.compare_experiment import comparison_linecut_records
+from pySED.compare_experiment import comparison_peak_records, comparison_residual_map
+from pySED.compare_experiment import comparison_summary, write_map_comparison_report
+from pySED.dsf import CurrentCorrelationResult, DSFResult, PartialDSFResult
+from pySED.dsf import compute_coherent_dsf_via_correlation
+from pySED.dsf import compute_current_correlations, compute_dsf, compute_partial_dsf
+from pySED.electron_kinematics import angular_resolution_to_q_sigma
+from pySED.electron_kinematics import eels_qpoints_from_angle_axis
+from pySED.electron_kinematics import electron_wavelength_angstrom
+from pySED.electron_kinematics import scattering_angles_to_qpoints
+from pySED.eels import EELSDecompositionMap, EELSMap, EELSVisibility
+from pySED.eels import build_eels_decomposition_map_from_mode_spectra
+from pySED.eels import compute_mode_visibility
+from pySED.eels import compute_mode_visibility_for_q_path
+from pySED.eigen_sed import EigenSEDResult, EigenvectorSet, compute_eigen_sed
+from pySED.mode_visibility import OnePhononDecompositionMap, OnePhononMap
+from pySED.mode_visibility import OnePhononVisibility
+from pySED.mode_visibility import build_one_phonon_decomposition_map_from_mode_spectra
+from pySED.mode_visibility import compute_one_phonon_visibility
+from pySED.mode_visibility import compute_one_phonon_visibility_for_q_path
+from pySED.q_advisor import ExtendedZoneQPathPlan, QAdvisor, QAdvisorReport
+from pySED.q_advisor import QPointAdvice, QPointMesh, QPathSegments, SelectedQEfficiencyReport
+from pySED.q_advisor import estimate_selected_q_efficiency
+from pySED.q_advisor import qpoints_from_mesh, qpoints_from_path_axis
+from pySED.q_advisor import qpoints_from_path_segments, split_extended_zone_qpoints
+from pySED.scattering_export import workflow_export_summary
+from pySED.scattering_export import write_scattering_workflow_bundle
+from pySED.scattering_input import ScatteringInputError
+from pySED.scattering_input import build_q_advisor_from_input
+from pySED.scattering_input import build_scattering_qpoints_from_input
+from pySED.scattering_input import run_q_advisor_from_input, run_scattering_from_input
+from pySED.scattering_workflow import CurrentCorrelationWorkflowResult, PartialDSFWorkflowResult
+from pySED.scattering_workflow import compute_current_correlation_workflow
+from pySED.scattering_workflow import compute_dsf_workflow, compute_eels_workflow
+from pySED.scattering_workflow import compute_eels_workflow_from_angle_axis
+from pySED.scattering_workflow import compute_eels_workflow_from_q_path
+from pySED.scattering_workflow import compute_one_phonon_workflow
+from pySED.scattering_workflow import compute_one_phonon_workflow_from_q_path
+from pySED.scattering_workflow import compute_partial_dsf_workflow
+from pySED.scattering_workflow import current_correlation_to_scattering_map
+from pySED.scattering_workflow import dsf_to_scattering_map
+from pySED.scattering_workflow import partial_dsf_to_scattering_map
+from pySED.visibility_diagnostics import ModeVisibilityDiagnostics
+from pySED.visibility_diagnostics import diagnose_mode_visibility
+
+__all__ = [
+    "__version__",
+    "CurrentCorrelationResult",
+    "CurrentCorrelationWorkflowResult",
+    "DSFResult",
+    "EELSDecompositionMap",
+    "EELSMap",
+    "EELSVisibility",
+    "EigenSEDResult",
+    "EigenvectorSet",
+    "ExtendedZoneQPathPlan",
+    "MapComparison",
+    "OnePhononDecompositionMap",
+    "OnePhononMap",
+    "OnePhononVisibility",
+    "PartialDSFResult",
+    "PartialDSFWorkflowResult",
+    "QAdvisor",
+    "QAdvisorReport",
+    "QPointAdvice",
+    "QPointMesh",
+    "QPathSegments",
+    "ScatteringInputError",
+    "SelectedQEfficiencyReport",
+    "estimate_selected_q_efficiency",
+    "qpoints_from_mesh",
+    "qpoints_from_path_axis",
+    "qpoints_from_path_segments",
+    "ScatteringMap",
+    "ModeVisibilityDiagnostics",
+    "build_eels_decomposition_map_from_mode_spectra",
+    "build_q_advisor_from_input",
+    "build_one_phonon_decomposition_map_from_mode_spectra",
+    "build_scattering_qpoints_from_input",
+    "angular_resolution_to_q_sigma",
+    "compute_coherent_dsf_via_correlation",
+    "compute_current_correlations",
+    "compute_current_correlation_workflow",
+    "comparison_linecut_records",
+    "comparison_peak_records",
+    "comparison_residual_map",
+    "comparison_summary",
+    "compute_dsf",
+    "compute_dsf_workflow",
+    "dsf_to_scattering_map",
+    "eels_qpoints_from_angle_axis",
+    "electron_wavelength_angstrom",
+    "compute_eels_workflow",
+    "compute_eels_workflow_from_angle_axis",
+    "compute_eels_workflow_from_q_path",
+    "compute_eigen_sed",
+    "compute_mode_visibility",
+    "compute_mode_visibility_for_q_path",
+    "compute_one_phonon_visibility",
+    "compute_one_phonon_visibility_for_q_path",
+    "compute_one_phonon_workflow",
+    "compute_one_phonon_workflow_from_q_path",
+    "compute_partial_dsf",
+    "compute_partial_dsf_workflow",
+    "current_correlation_to_scattering_map",
+    "diagnose_mode_visibility",
+    "partial_dsf_to_scattering_map",
+    "run_q_advisor_from_input",
+    "run_scattering_from_input",
+    "scattering_angles_to_qpoints",
+    "split_extended_zone_qpoints",
+    "write_map_comparison_report",
+    "workflow_export_summary",
+    "write_scattering_workflow_bundle",
+]

--- a/pySED/compare_experiment.py
+++ b/pySED/compare_experiment.py
@@ -1,0 +1,620 @@
+"""Utilities for comparing simulated scattering maps with experiments."""
+
+from dataclasses import dataclass
+from pathlib import Path
+import csv
+import json
+
+import numpy as np
+from scipy.interpolate import interp1d
+from scipy.ndimage import gaussian_filter, gaussian_filter1d
+
+from pySED.quantum_correction import apply_quantum_correction
+
+
+@dataclass
+class ScatteringMap:
+    q_axis: np.ndarray
+    energy_axis: np.ndarray
+    intensity: np.ndarray
+    metadata: dict = None
+
+    def __post_init__(self):
+        self.q_axis = np.asarray(self.q_axis, dtype=float)
+        self.energy_axis = np.asarray(self.energy_axis, dtype=float)
+        self.intensity = np.asarray(self.intensity, dtype=float)
+        if self.intensity.ndim != 2:
+            raise ValueError("ScatteringMap intensity must have shape (num_q, num_energy)")
+        if self.intensity.shape != (self.q_axis.size, self.energy_axis.size):
+            raise ValueError("intensity shape must match q_axis and energy_axis lengths")
+        if self.metadata is None:
+            self.metadata = {}
+
+
+@dataclass
+class MapComparison:
+    simulated: np.ndarray
+    experimental: np.ndarray
+    residual: np.ndarray
+    rmse: float
+    mae: float
+    correlation: float
+    simulated_map: object = None
+    experimental_map: object = None
+
+
+def load_intensity_map(path, delimiter=None):
+    """Load an experimental intensity map from .npy or text/CSV."""
+
+    path = str(path)
+    if path.lower().endswith(".npy"):
+        return np.load(path)
+    return np.loadtxt(path, delimiter=delimiter)
+
+
+def _as_float_image(image):
+    arr = np.asarray(image)
+    if np.issubdtype(arr.dtype, np.integer):
+        arr = arr.astype(float) / float(np.iinfo(arr.dtype).max)
+    else:
+        arr = arr.astype(float)
+    return arr
+
+
+def image_to_grayscale(image, channel_weights=(0.299, 0.587, 0.114)):
+    """Convert a grayscale/RGB/RGBA image array to a 2D intensity array."""
+
+    arr = _as_float_image(image)
+    if arr.ndim == 2:
+        return arr
+    if arr.ndim != 3 or arr.shape[2] < 3:
+        raise ValueError("image must be a 2D grayscale array or an RGB/RGBA array")
+    weights = np.asarray(channel_weights, dtype=float)
+    if weights.shape != (3,):
+        raise ValueError("channel_weights must contain three RGB weights")
+    weights = weights / np.sum(weights)
+    return np.tensordot(arr[:, :, :3], weights, axes=([2], [0]))
+
+
+def crop_image(image, crop=None):
+    """Crop an image with ``(row_start, row_stop, col_start, col_stop)``."""
+
+    arr = np.asarray(image)
+    if crop is None:
+        return arr
+    if len(crop) != 4:
+        raise ValueError("crop must be (row_start, row_stop, col_start, col_stop)")
+    row_start, row_stop, col_start, col_stop = [int(value) for value in crop]
+    if row_start < 0 or col_start < 0 or row_stop <= row_start or col_stop <= col_start:
+        raise ValueError("crop bounds must be positive and ordered")
+    if row_stop > arr.shape[0] or col_stop > arr.shape[1]:
+        raise ValueError("crop bounds exceed image dimensions")
+    return arr[row_start:row_stop, col_start:col_stop]
+
+
+def scattering_map_from_image(
+    image,
+    q_range,
+    energy_range,
+    crop=None,
+    invert=False,
+    origin="upper",
+    normalization=None,
+    channel_weights=(0.299, 0.587, 0.114),
+    metadata=None,
+):
+    """Calibrate an image array into a :class:`ScatteringMap`.
+
+    ``q_range`` is mapped left-to-right across image columns.  ``energy_range``
+    is mapped bottom-to-top for ``origin="upper"`` images, matching ordinary
+    image files where row zero is the top of the image.
+    """
+
+    if len(q_range) != 2 or len(energy_range) != 2:
+        raise ValueError("q_range and energy_range must each contain two values")
+    if origin not in ("upper", "lower"):
+        raise ValueError("origin must be 'upper' or 'lower'")
+
+    cropped = crop_image(image, crop=crop)
+    intensity = image_to_grayscale(cropped, channel_weights=channel_weights)
+    if invert:
+        intensity = np.nanmax(intensity) - intensity
+    if origin == "upper":
+        intensity = intensity[::-1, :]
+
+    if normalization is not None:
+        intensity = normalize_intensity(intensity, normalization)
+
+    n_energy, n_q = intensity.shape
+    q_axis = np.linspace(float(q_range[0]), float(q_range[1]), n_q)
+    energy_axis = np.linspace(float(energy_range[0]), float(energy_range[1]), n_energy)
+    map_metadata = dict(metadata or {})
+    map_metadata.update(
+        {
+            "source": "calibrated image",
+            "crop": crop,
+            "origin": origin,
+            "inverted": bool(invert),
+            "normalization": normalization,
+        }
+    )
+    return ScatteringMap(q_axis, energy_axis, intensity.T, map_metadata)
+
+
+def load_scattering_map_image(
+    path,
+    q_range,
+    energy_range,
+    crop=None,
+    invert=False,
+    origin="upper",
+    normalization=None,
+    channel_weights=(0.299, 0.587, 0.114),
+    metadata=None,
+):
+    """Load an image file and calibrate it into a :class:`ScatteringMap`."""
+
+    try:
+        from matplotlib import image as mpimg
+    except ImportError as exc:
+        raise ImportError("matplotlib is required to load image intensity maps") from exc
+
+    image = mpimg.imread(path)
+    map_metadata = dict(metadata or {})
+    map_metadata["image_path"] = str(path)
+    return scattering_map_from_image(
+        image,
+        q_range=q_range,
+        energy_range=energy_range,
+        crop=crop,
+        invert=invert,
+        origin=origin,
+        normalization=normalization,
+        channel_weights=channel_weights,
+        metadata=map_metadata,
+    )
+
+
+def normalize_intensity(intensity, method="max", eps=1e-30):
+    arr = np.asarray(intensity, dtype=float)
+    if method == "none" or method is None:
+        return arr.copy()
+    if method == "max":
+        scale = np.nanmax(np.abs(arr))
+        return arr / (scale + eps)
+    if method == "area":
+        scale = np.nansum(np.abs(arr))
+        return arr / (scale + eps)
+    if method == "zscore":
+        return (arr - np.nanmean(arr)) / (np.nanstd(arr) + eps)
+    raise ValueError("method must be 'none', 'max', 'area', or 'zscore'")
+
+
+def interpolate_energy_axis(intensity, source_energy, target_energy, axis=-1):
+    source = np.asarray(source_energy, dtype=float)
+    target = np.asarray(target_energy, dtype=float)
+    func = interp1d(source, intensity, axis=axis, bounds_error=False, fill_value=0.0)
+    return func(target)
+
+
+def align_intensity_map(intensity, source_q, source_energy, target_q, target_energy):
+    """Interpolate a 2D q-energy map onto target experimental axes."""
+
+    arr = np.asarray(intensity, dtype=float)
+    source_q = np.asarray(source_q, dtype=float)
+    source_energy = np.asarray(source_energy, dtype=float)
+    target_q = np.asarray(target_q, dtype=float)
+    target_energy = np.asarray(target_energy, dtype=float)
+
+    if arr.shape != (source_q.size, source_energy.size):
+        raise ValueError("intensity shape must match source_q and source_energy lengths")
+
+    energy_aligned = interpolate_energy_axis(arr, source_energy, target_energy, axis=1)
+    if source_q.size == 1:
+        q_aligned = np.zeros((target_q.size, target_energy.size), dtype=float)
+        matching = np.isclose(target_q, source_q[0])
+        q_aligned[matching] = energy_aligned[0]
+        return q_aligned
+
+    q_func = interp1d(source_q, energy_aligned, axis=0, bounds_error=False, fill_value=0.0)
+    return q_func(target_q)
+
+
+def _axis_sigma_points(axis, sigma):
+    if sigma is None or sigma == 0:
+        return 0.0
+    axis = np.asarray(axis, dtype=float)
+    if axis.ndim != 1 or axis.size < 2:
+        raise ValueError("axis must contain at least two points")
+    diffs = np.diff(axis)
+    if np.any(diffs == 0):
+        raise ValueError("axis values must be distinct")
+    spacing = float(np.mean(np.abs(diffs)))
+    return abs(float(sigma)) / spacing
+
+
+def broaden_energy(intensity, sigma_points, axis=-1):
+    return gaussian_filter1d(intensity, sigma=sigma_points, axis=axis, mode="nearest")
+
+
+def convolve_q_resolution(intensity, sigma_q_points, sigma_energy_points=0.0):
+    sigma = [sigma_q_points] * np.asarray(intensity).ndim
+    sigma[-1] = sigma_energy_points
+    return gaussian_filter(intensity, sigma=sigma, mode="nearest")
+
+
+def convolve_resolution_units(scattering_map, sigma_q=None, sigma_energy=None):
+    """Apply Gaussian q/energy resolution using physical axis units."""
+
+    if not isinstance(scattering_map, ScatteringMap):
+        raise TypeError("scattering_map must be a ScatteringMap")
+    sigma_q_points = _axis_sigma_points(scattering_map.q_axis, sigma_q)
+    sigma_energy_points = _axis_sigma_points(scattering_map.energy_axis, sigma_energy)
+    intensity = gaussian_filter(
+        scattering_map.intensity,
+        sigma=(sigma_q_points, sigma_energy_points),
+        mode="nearest",
+    )
+    metadata = dict(scattering_map.metadata)
+    metadata.update(
+        {
+            "sigma_q": sigma_q,
+            "sigma_energy": sigma_energy,
+            "sigma_q_points": sigma_q_points,
+            "sigma_energy_points": sigma_energy_points,
+        }
+    )
+    return ScatteringMap(scattering_map.q_axis, scattering_map.energy_axis, intensity, metadata)
+
+
+def apply_quantum_correction_to_map(scattering_map, temperature, energy_unit="thz"):
+    """Apply the harmonic classical-to-quantum correction to a map."""
+
+    if not isinstance(scattering_map, ScatteringMap):
+        raise TypeError("scattering_map must be a ScatteringMap")
+    intensity = apply_quantum_correction(
+        scattering_map.intensity,
+        scattering_map.energy_axis,
+        temperature,
+        unit=energy_unit,
+        axis_index=1,
+    )
+    metadata = dict(scattering_map.metadata)
+    metadata.update(
+        {
+            "quantum_correction": "harmonic classical-to-quantum detailed-balance factor",
+            "quantum_temperature_kelvin": float(temperature),
+            "energy_unit": energy_unit,
+        }
+    )
+    return ScatteringMap(scattering_map.q_axis, scattering_map.energy_axis, intensity, metadata)
+
+
+def align_to_experiment(simulated_map, experimental_map):
+    """Return the simulated map interpolated onto the experimental axes."""
+
+    if not isinstance(simulated_map, ScatteringMap) or not isinstance(experimental_map, ScatteringMap):
+        raise TypeError("simulated_map and experimental_map must be ScatteringMap instances")
+    aligned = align_intensity_map(
+        simulated_map.intensity,
+        simulated_map.q_axis,
+        simulated_map.energy_axis,
+        experimental_map.q_axis,
+        experimental_map.energy_axis,
+    )
+    metadata = dict(simulated_map.metadata)
+    metadata.update({"aligned_to": "experimental axes"})
+    return ScatteringMap(experimental_map.q_axis, experimental_map.energy_axis, aligned, metadata)
+
+
+def compare_maps(simulated, experimental, normalization="max"):
+    sim = normalize_intensity(simulated, normalization)
+    exp = normalize_intensity(experimental, normalization)
+    if sim.shape != exp.shape:
+        raise ValueError("simulated and experimental maps must have the same shape")
+    residual = sim - exp
+    rmse = float(np.sqrt(np.nanmean(residual ** 2)))
+    mae = float(np.nanmean(np.abs(residual)))
+    sim_flat = sim.ravel()
+    exp_flat = exp.ravel()
+    if np.nanstd(sim_flat) == 0 or np.nanstd(exp_flat) == 0:
+        corr = np.nan
+    else:
+        corr = float(np.corrcoef(sim_flat, exp_flat)[0, 1])
+    return MapComparison(sim, exp, residual, rmse, mae, corr)
+
+
+def prepare_map_comparison(
+    simulated_map,
+    experimental_map,
+    sigma_q=None,
+    sigma_energy=None,
+    normalization="max",
+    quantum_temperature=None,
+    energy_unit="thz",
+):
+    """Align, optionally quantum-correct, broaden, normalize, and compare maps."""
+
+    aligned = align_to_experiment(simulated_map, experimental_map)
+    if quantum_temperature is not None:
+        aligned = apply_quantum_correction_to_map(
+            aligned,
+            temperature=quantum_temperature,
+            energy_unit=energy_unit,
+        )
+    broadened = convolve_resolution_units(aligned, sigma_q=sigma_q, sigma_energy=sigma_energy)
+    comparison = compare_maps(
+        broadened.intensity,
+        experimental_map.intensity,
+        normalization=normalization,
+    )
+    comparison.simulated_map = broadened
+    comparison.experimental_map = experimental_map
+    return comparison
+
+
+def linecut(intensity, index, axis=0):
+    return np.take(np.asarray(intensity), indices=index, axis=axis)
+
+
+def track_peak_positions(intensity, energy_axis, axis=-1):
+    arr = np.asarray(intensity)
+    energy = np.asarray(energy_axis)
+    peak_indices = np.argmax(arr, axis=axis)
+    return energy[peak_indices]
+
+
+def _finite_float_or_none(value):
+    value = float(value)
+    return value if np.isfinite(value) else None
+
+
+def _json_safe(value):
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, float):
+        return value if np.isfinite(value) else None
+    return value
+
+
+def _comparison_axes(comparison):
+    if comparison.experimental_map is not None:
+        q_axis = np.asarray(comparison.experimental_map.q_axis, dtype=float)
+        energy_axis = np.asarray(comparison.experimental_map.energy_axis, dtype=float)
+    else:
+        q_axis = np.arange(np.asarray(comparison.experimental).shape[0], dtype=float)
+        energy_axis = np.arange(np.asarray(comparison.experimental).shape[1], dtype=float)
+    return q_axis, energy_axis
+
+
+def comparison_summary(comparison):
+    """Return JSON-ready scalar metrics for a map comparison."""
+
+    simulated = np.asarray(comparison.simulated, dtype=float)
+    experimental = np.asarray(comparison.experimental, dtype=float)
+    residual = np.asarray(comparison.residual, dtype=float)
+    q_axis, energy_axis = _comparison_axes(comparison)
+    summary = {
+        "rmse": _finite_float_or_none(comparison.rmse),
+        "mae": _finite_float_or_none(comparison.mae),
+        "correlation": _finite_float_or_none(comparison.correlation),
+        "simulated_shape": list(simulated.shape),
+        "experimental_shape": list(experimental.shape),
+        "residual_max_abs": _finite_float_or_none(np.nanmax(np.abs(residual))) if residual.size else 0.0,
+        "residual_mean": _finite_float_or_none(np.nanmean(residual)) if residual.size else 0.0,
+        "q_min": _finite_float_or_none(np.nanmin(q_axis)) if q_axis.size else None,
+        "q_max": _finite_float_or_none(np.nanmax(q_axis)) if q_axis.size else None,
+        "energy_min": _finite_float_or_none(np.nanmin(energy_axis)) if energy_axis.size else None,
+        "energy_max": _finite_float_or_none(np.nanmax(energy_axis)) if energy_axis.size else None,
+        "has_simulated_map": comparison.simulated_map is not None,
+        "has_experimental_map": comparison.experimental_map is not None,
+    }
+    if comparison.simulated_map is not None:
+        summary["simulated_metadata"] = _json_safe(dict(comparison.simulated_map.metadata))
+    if comparison.experimental_map is not None:
+        summary["experimental_metadata"] = _json_safe(dict(comparison.experimental_map.metadata))
+    return summary
+
+
+def comparison_peak_records(comparison):
+    """Return peak-tracking rows along the energy axis for every q point."""
+
+    q_axis, energy_axis = _comparison_axes(comparison)
+    simulated = np.asarray(comparison.simulated, dtype=float)
+    experimental = np.asarray(comparison.experimental, dtype=float)
+    if simulated.shape != experimental.shape:
+        raise ValueError("simulated and experimental arrays must have the same shape")
+    if simulated.shape != (q_axis.size, energy_axis.size):
+        raise ValueError("comparison arrays must match q and energy axes")
+
+    sim_peak_index = np.argmax(simulated, axis=1)
+    exp_peak_index = np.argmax(experimental, axis=1)
+    records = []
+    for index, q_value in enumerate(q_axis):
+        sim_idx = int(sim_peak_index[index])
+        exp_idx = int(exp_peak_index[index])
+        sim_energy = float(energy_axis[sim_idx])
+        exp_energy = float(energy_axis[exp_idx])
+        records.append(
+            {
+                "q_index": int(index),
+                "q_value": float(q_value),
+                "simulated_peak_energy": sim_energy,
+                "experimental_peak_energy": exp_energy,
+                "peak_energy_delta": sim_energy - exp_energy,
+                "simulated_peak_intensity": float(simulated[index, sim_idx]),
+                "experimental_peak_intensity": float(experimental[index, exp_idx]),
+            }
+        )
+    return records
+
+
+def _coerce_indices(indices, axis_size, name):
+    if indices is None:
+        return []
+    if np.isscalar(indices):
+        indices = [indices]
+    output = []
+    for value in indices:
+        index = int(value)
+        if index < 0:
+            index += axis_size
+        if index < 0 or index >= axis_size:
+            raise IndexError("%s index %d is out of bounds" % (name, int(value)))
+        output.append(index)
+    return output
+
+
+def comparison_linecut_records(comparison, q_indices=None, energy_indices=None):
+    """Return fixed-q and fixed-energy line-cut records.
+
+    The records use the normalized arrays stored in
+    :class:`pySED.compare_experiment.MapComparison`, so they match the residual
+    and scalar metrics used in the paper-ready comparison.
+    """
+
+    q_axis, energy_axis = _comparison_axes(comparison)
+    simulated = np.asarray(comparison.simulated, dtype=float)
+    experimental = np.asarray(comparison.experimental, dtype=float)
+    residual = np.asarray(comparison.residual, dtype=float)
+    if simulated.shape != experimental.shape or simulated.shape != residual.shape:
+        raise ValueError("comparison arrays must have the same shape")
+    if simulated.shape != (q_axis.size, energy_axis.size):
+        raise ValueError("comparison arrays must match q and energy axes")
+
+    q_indices = _coerce_indices(q_indices, q_axis.size, "q")
+    energy_indices = _coerce_indices(energy_indices, energy_axis.size, "energy")
+    records = []
+    for q_index in q_indices:
+        for energy_index, energy_value in enumerate(energy_axis):
+            records.append(
+                {
+                    "cut_axis": "energy_at_q",
+                    "cut_index": int(q_index),
+                    "q_index": int(q_index),
+                    "energy_index": int(energy_index),
+                    "q_value": float(q_axis[q_index]),
+                    "energy_value": float(energy_value),
+                    "simulated": float(simulated[q_index, energy_index]),
+                    "experimental": float(experimental[q_index, energy_index]),
+                    "residual": float(residual[q_index, energy_index]),
+                }
+            )
+    for energy_index in energy_indices:
+        for q_index, q_value in enumerate(q_axis):
+            records.append(
+                {
+                    "cut_axis": "q_at_energy",
+                    "cut_index": int(energy_index),
+                    "q_index": int(q_index),
+                    "energy_index": int(energy_index),
+                    "q_value": float(q_value),
+                    "energy_value": float(energy_axis[energy_index]),
+                    "simulated": float(simulated[q_index, energy_index]),
+                    "experimental": float(experimental[q_index, energy_index]),
+                    "residual": float(residual[q_index, energy_index]),
+                }
+            )
+    return records
+
+
+def map_value_records(scattering_map, value_name="intensity"):
+    """Return flattened q-energy map records for CSV export."""
+
+    if not isinstance(scattering_map, ScatteringMap):
+        raise TypeError("scattering_map must be a ScatteringMap")
+    records = []
+    for i_q, q_value in enumerate(scattering_map.q_axis):
+        for i_energy, energy_value in enumerate(scattering_map.energy_axis):
+            records.append(
+                {
+                    "q_index": int(i_q),
+                    "energy_index": int(i_energy),
+                    "q_value": float(q_value),
+                    "energy_value": float(energy_value),
+                    value_name: float(scattering_map.intensity[i_q, i_energy]),
+                }
+            )
+    return records
+
+
+def comparison_residual_map(comparison):
+    """Return the residual as a calibrated :class:`ScatteringMap`."""
+
+    q_axis, energy_axis = _comparison_axes(comparison)
+    metadata = {
+        "source": "pySED map comparison residual",
+        "definition": "normalized simulated intensity minus normalized experimental intensity",
+        "rmse": _finite_float_or_none(comparison.rmse),
+        "mae": _finite_float_or_none(comparison.mae),
+        "correlation": _finite_float_or_none(comparison.correlation),
+    }
+    return ScatteringMap(q_axis, energy_axis, comparison.residual, metadata)
+
+
+def _write_records_csv(path, records):
+    records = list(records)
+    fieldnames = list(records[0].keys()) if records else []
+    with open(path, "w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        if fieldnames:
+            writer.writeheader()
+            writer.writerows(records)
+
+
+def write_map_comparison_report(
+    comparison,
+    output_dir,
+    prefix="comparison",
+    write_residual=True,
+    write_peaks=True,
+    linecut_q_indices=None,
+    linecut_energy_indices=None,
+):
+    """Write paper-ready comparison metrics and tables.
+
+    The report consists of a JSON summary plus optional flattened CSV tables for
+    the residual map, q-resolved peak tracking, and fixed-q/fixed-energy line
+    cuts.
+    """
+
+    output = Path(output_dir)
+    output.mkdir(parents=True, exist_ok=True)
+    prefix = str(prefix)
+    written = {}
+
+    summary_path = output / ("%s_summary.json" % prefix)
+    with open(summary_path, "w", encoding="utf-8") as handle:
+        json.dump(comparison_summary(comparison), handle, indent=2, sort_keys=True)
+    written["summary"] = str(summary_path)
+
+    if write_residual:
+        residual_path = output / ("%s_residual.csv" % prefix)
+        _write_records_csv(
+            residual_path,
+            map_value_records(comparison_residual_map(comparison), value_name="residual"),
+        )
+        written["residual"] = str(residual_path)
+
+    if write_peaks:
+        peaks_path = output / ("%s_peaks.csv" % prefix)
+        _write_records_csv(peaks_path, comparison_peak_records(comparison))
+        written["peaks"] = str(peaks_path)
+
+    linecut_records = comparison_linecut_records(
+        comparison,
+        q_indices=linecut_q_indices,
+        energy_indices=linecut_energy_indices,
+    )
+    if linecut_records:
+        linecuts_path = output / ("%s_linecuts.csv" % prefix)
+        _write_records_csv(linecuts_path, linecut_records)
+        written["linecuts"] = str(linecuts_path)
+
+    return written

--- a/pySED/dsf.py
+++ b/pySED/dsf.py
@@ -1,0 +1,662 @@
+"""Dynamic structure factor calculations from MD trajectories.
+
+This module implements the density-correlation route used for neutron and
+X-ray inelastic scattering.  The computation is organized in terms of
+
+    rho(Q, t) = sum_i w_i(Q) exp(i Q dot r_i(t))
+
+and estimates the coherent spectrum from the time Fourier transform of rho.
+This is equivalent to evaluating the intermediate scattering function and then
+Fourier transforming it, but avoids storing F(Q, t) explicitly.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from pySED.probe_weights import ATOMIC_NUMBERS, atomic_number_weights
+from pySED.probe_weights import xray_form_factor_weights as _xray_form_factor_weights
+from pySED.scattering_kernel import (
+    as_blocks,
+    circular_autocorrelation,
+    density_amplitude,
+    density_amplitude_from_phase,
+    fft_power,
+    frequency_grid,
+    phase_factors,
+    resolve_backend,
+    standard_error,
+    to_numpy,
+)
+
+
+NEUTRON_COHERENT_LENGTHS_FM = {
+    "H": -3.7390,
+    "D": 6.671,
+    "B": 5.30,
+    "C": 6.6460,
+    "N": 9.36,
+    "O": 5.803,
+    "Na": 3.63,
+    "Al": 3.449,
+    "Si": 4.1491,
+    "P": 5.13,
+    "S": 2.847,
+    "Mo": 6.715,
+    "Cu": 7.718,
+    "Se": 7.970,
+    "Zr": 7.16,
+    "W": 4.86,
+}
+
+NEUTRON_INCOHERENT_XS_BARN = {
+    "H": 80.26,
+    "D": 2.05,
+    "B": 1.7,
+    "C": 0.001,
+    "N": 0.5,
+    "O": 0.0008,
+    "Na": 1.62,
+    "Al": 0.0082,
+    "Si": 0.004,
+    "P": 0.005,
+    "S": 0.007,
+    "Mo": 0.04,
+    "Cu": 0.55,
+    "Se": 0.32,
+    "Zr": 0.02,
+    "W": 1.63,
+}
+
+@dataclass
+class DSFResult:
+    qpoints_cartesian: np.ndarray
+    frequencies_thz: np.ndarray
+    coherent: np.ndarray
+    incoherent: np.ndarray
+    total: np.ndarray
+    elastic_coherent: np.ndarray
+    elastic_incoherent: np.ndarray
+    num_blocks: int
+    metadata: dict
+    coherent_sem: np.ndarray = None
+    incoherent_sem: np.ndarray = None
+    total_sem: np.ndarray = None
+    elastic_coherent_sem: np.ndarray = None
+    elastic_incoherent_sem: np.ndarray = None
+
+
+@dataclass
+class CurrentCorrelationResult:
+    qpoints_cartesian: np.ndarray
+    frequencies_thz: np.ndarray
+    longitudinal: np.ndarray
+    transverse: np.ndarray
+    num_blocks: int
+    longitudinal_sem: np.ndarray = None
+    transverse_sem: np.ndarray = None
+    metadata: dict = None
+
+
+@dataclass
+class PartialDSFResult:
+    qpoints_cartesian: np.ndarray
+    frequencies_thz: np.ndarray
+    species: tuple
+    partial: np.ndarray
+    partial_sem: np.ndarray
+    weighted_total: np.ndarray
+    weighted_total_sem: np.ndarray
+    num_blocks: int
+    metadata: dict
+
+
+def _weights_from_atom_types(atom_types, table, missing="raise"):
+    if atom_types is None:
+        return None
+    values = []
+    for atom in atom_types:
+        key = str(atom)
+        if key not in table:
+            if missing == "zero":
+                values.append(0.0)
+                continue
+            raise KeyError("missing scattering data for atom type %s" % key)
+        values.append(float(table[key]))
+    return np.asarray(values, dtype=float)
+
+
+def neutron_weights(atom_types, include_incoherent=True):
+    coherent = _weights_from_atom_types(atom_types, NEUTRON_COHERENT_LENGTHS_FM)
+    incoherent = None
+    if include_incoherent:
+        incoherent = _weights_from_atom_types(atom_types, NEUTRON_INCOHERENT_XS_BARN)
+    return coherent, incoherent
+
+
+def xray_atomic_number_weights(atom_types, qpoints_cartesian=None):
+    """Return an approximate X-ray weight using atomic number.
+
+    This is a safe default when no tabulated form-factor data are supplied.  For
+    publication-quality X-ray comparison, pass q-dependent form factors through
+    ``coherent_weights``.
+    """
+
+    return atomic_number_weights(atom_types, qpoints_cartesian=qpoints_cartesian)
+
+
+def xray_form_factor_weights(
+    atom_types,
+    qpoints_cartesian=None,
+    coefficients_table=None,
+    missing="atomic_number",
+):
+    """Return q-dependent X-ray form-factor weights.
+
+    This thin wrapper exposes :mod:`pySED.probe_weights` through the historical
+    DSF namespace.
+    """
+
+    return _xray_form_factor_weights(
+        atom_types,
+        qpoints_cartesian=qpoints_cartesian,
+        coefficients_table=coefficients_table,
+        missing=missing,
+    )
+
+
+def resolve_scattering_weights(
+    atom_types=None,
+    qpoints_cartesian=None,
+    experiment="neutron",
+    coherent_weights=None,
+    incoherent_cross_sections=None,
+    xray_form_factor_table=None,
+    xray_missing="atomic_number",
+):
+    qpoints = np.atleast_2d(qpoints_cartesian) if qpoints_cartesian is not None else None
+
+    if coherent_weights is not None:
+        coherent = np.asarray(coherent_weights, dtype=float)
+    elif experiment == "neutron":
+        coherent, _ = neutron_weights(atom_types, include_incoherent=False)
+    elif experiment == "xray":
+        coherent = xray_form_factor_weights(
+            atom_types,
+            qpoints_cartesian=qpoints,
+            coefficients_table=xray_form_factor_table,
+            missing=xray_missing,
+        )
+    elif experiment == "custom":
+        coherent = None
+    else:
+        raise ValueError("experiment must be 'neutron', 'xray', or 'custom'")
+
+    if incoherent_cross_sections is not None:
+        incoherent = np.asarray(incoherent_cross_sections, dtype=float)
+    elif experiment == "neutron":
+        _, incoherent = neutron_weights(atom_types, include_incoherent=True)
+    else:
+        incoherent = None
+
+    return coherent, incoherent
+
+
+def _weights_for_q(weights, q_index, num_atoms):
+    if weights is None:
+        return np.ones(num_atoms, dtype=float)
+    weights = np.asarray(weights, dtype=float)
+    if weights.ndim == 1:
+        if weights.shape[0] != num_atoms:
+            raise ValueError("weights length must match number of atoms")
+        return weights
+    if weights.ndim == 2:
+        if weights.shape[1] != num_atoms:
+            raise ValueError("q-dependent weights must have shape (num_qpoints, num_atoms)")
+        return weights[q_index]
+    raise ValueError("weights must be one- or two-dimensional")
+
+
+def _species_groups(atom_types):
+    if atom_types is None:
+        raise ValueError("atom_types must be supplied for partial DSF")
+    labels = tuple(dict.fromkeys(str(atom) for atom in atom_types))
+    atom_types = np.asarray([str(atom) for atom in atom_types])
+    groups = [np.flatnonzero(atom_types == label) for label in labels]
+    return labels, groups
+
+
+def _species_weights_for_q(species_weights, species, q_index):
+    n_species = len(species)
+    if species_weights is None:
+        return np.ones(n_species, dtype=float)
+    if isinstance(species_weights, dict):
+        return np.asarray([species_weights[label] for label in species])
+    weights = np.asarray(species_weights)
+    if weights.ndim == 1:
+        if weights.shape[0] != n_species:
+            raise ValueError("species_weights length must match number of species")
+        return weights
+    if weights.ndim == 2:
+        if weights.shape[1] != n_species:
+            raise ValueError("q-dependent species_weights must have shape (num_qpoints, num_species)")
+        return weights[q_index]
+    raise ValueError("species_weights must be a dict, 1D array, or 2D array")
+
+
+def compute_dsf(
+    positions,
+    qpoints_cartesian,
+    dt,
+    atom_types=None,
+    experiment="neutron",
+    coherent_weights=None,
+    incoherent_cross_sections=None,
+    xray_form_factor_table=None,
+    xray_missing="atomic_number",
+    num_blocks=1,
+    positive_only=True,
+    backend="cpu",
+):
+    """Compute coherent/incoherent dynamic structure factors.
+
+    Parameters
+    ----------
+    positions
+        Array with shape ``(num_frames, num_atoms, 3)`` in Angstrom.
+    qpoints_cartesian
+        Q points in inverse Angstrom, including the ``2*pi`` convention.
+    dt
+        Sampling interval in seconds.
+    backend
+        ``"cpu"``/``"numpy"`` by default.  Use ``"cupy"`` or ``"gpu"`` only
+        when CuPy is installed for the local CUDA runtime.
+    """
+
+    positions = np.asarray(positions, dtype=float)
+    if positions.ndim != 3 or positions.shape[2] != 3:
+        raise ValueError("positions must have shape (num_frames, num_atoms, 3)")
+    qpoints = np.atleast_2d(np.asarray(qpoints_cartesian, dtype=float))
+    if qpoints.shape[1] != 3:
+        raise ValueError("qpoints_cartesian must have shape (num_qpoints, 3)")
+    kernel = resolve_backend(backend)
+    xp = kernel.xp
+
+    n_frames, n_atoms, _ = positions.shape
+    blocks = as_blocks(n_frames, num_blocks)
+    block_size = blocks[0][1] - blocks[0][0]
+    grid = frequency_grid(block_size, dt, positive_only=positive_only, backend=kernel)
+    freq_slice = grid.freq_slice
+    freq_out = grid.frequencies_thz
+    user_coherent_weights = coherent_weights is not None
+
+    coherent_weights, incoherent_cross_sections = resolve_scattering_weights(
+        atom_types=atom_types,
+        qpoints_cartesian=qpoints,
+        experiment=experiment,
+        coherent_weights=coherent_weights,
+        incoherent_cross_sections=incoherent_cross_sections,
+        xray_form_factor_table=xray_form_factor_table,
+        xray_missing=xray_missing,
+    )
+
+    n_q = qpoints.shape[0]
+    n_f = len(freq_out)
+    coherent_blocks = np.zeros((num_blocks, n_q, n_f), dtype=float)
+    incoherent_blocks = np.zeros((num_blocks, n_q, n_f), dtype=float)
+    elastic_coherent_blocks = np.zeros((num_blocks, n_q), dtype=float)
+    elastic_incoherent_blocks = np.zeros((num_blocks, n_q), dtype=float)
+
+    calc_coherent = coherent_weights is not None or experiment in ("neutron", "xray", "custom")
+    calc_incoherent = incoherent_cross_sections is not None
+
+    block_norm = float(block_size * n_atoms)
+    for block_index, (start, stop) in enumerate(blocks):
+        block = positions[start:stop]
+        for q_index, q_vec in enumerate(qpoints):
+            phase = phase_factors(block, q_vec, backend=kernel)
+
+            if calc_coherent:
+                w = _weights_for_q(coherent_weights, q_index, n_atoms)
+                rho = density_amplitude_from_phase(phase, w, backend=kernel)
+                elastic_coherent_blocks[block_index, q_index] = (
+                    to_numpy(xp.abs(xp.mean(rho)) ** 2, kernel) / block_norm
+                )
+                spectrum = fft_power(rho, norm="forward", backend=kernel)
+                coherent_blocks[block_index, q_index] = (
+                    to_numpy(spectrum[freq_slice].real, kernel) / block_norm
+                )
+
+            if calc_incoherent:
+                sigma = _weights_for_q(incoherent_cross_sections, q_index, n_atoms)
+                sigma_backend = xp.asarray(sigma)
+                atom_fft = kernel.fft(phase.T, axis=1, norm="forward")
+                elastic_incoherent_blocks[block_index, q_index] = (
+                    to_numpy(
+                        xp.sum(sigma_backend * xp.abs(xp.mean(phase.T, axis=1)) ** 2),
+                        kernel,
+                    )
+                    / block_norm
+                )
+                spectrum = xp.sum(
+                    sigma_backend.reshape(-1, 1) * xp.abs(atom_fft) ** 2,
+                    axis=0,
+                )
+                incoherent_blocks[block_index, q_index] = (
+                    to_numpy(spectrum[freq_slice].real, kernel) / block_norm
+                )
+
+    coherent = np.mean(coherent_blocks, axis=0)
+    incoherent = np.mean(incoherent_blocks, axis=0)
+    elastic_coherent = np.mean(elastic_coherent_blocks, axis=0)
+    elastic_incoherent = np.mean(elastic_incoherent_blocks, axis=0)
+    coherent_sem = standard_error(coherent_blocks)
+    incoherent_sem = standard_error(incoherent_blocks)
+    elastic_coherent_sem = standard_error(elastic_coherent_blocks)
+    elastic_incoherent_sem = standard_error(elastic_incoherent_blocks)
+    total_blocks = coherent_blocks + incoherent_blocks
+    total = coherent + incoherent
+    total_sem = standard_error(total_blocks)
+
+    return DSFResult(
+        qpoints_cartesian=qpoints,
+        frequencies_thz=freq_out,
+        coherent=coherent,
+        incoherent=incoherent,
+        total=total,
+        elastic_coherent=elastic_coherent,
+        elastic_incoherent=elastic_incoherent,
+        num_blocks=num_blocks,
+        metadata={
+            "experiment": experiment,
+            "dt_seconds": float(dt),
+            "positive_only": bool(positive_only),
+            "backend": kernel.name,
+            "xray_weights": (
+                "user supplied coherent_weights"
+                if experiment == "xray" and user_coherent_weights
+                else "Cromer-Mann form factors with atomic-number fallback"
+                if experiment == "xray"
+                else None
+            ),
+            "normalization": "block spectra divided by block_size * num_atoms, then averaged",
+            "uncertainty": "standard error of the block-averaged spectra",
+        },
+        coherent_sem=coherent_sem,
+        incoherent_sem=incoherent_sem,
+        total_sem=total_sem,
+        elastic_coherent_sem=elastic_coherent_sem,
+        elastic_incoherent_sem=elastic_incoherent_sem,
+    )
+
+
+def compute_partial_dsf(
+    positions,
+    qpoints_cartesian,
+    dt,
+    atom_types,
+    species_weights=None,
+    num_blocks=1,
+    positive_only=True,
+    backend="cpu",
+):
+    """Compute species-pair coherent partial DSF matrices.
+
+    The returned ``partial`` array has shape
+    ``(num_qpoints, num_species, num_species, num_frequencies)`` and contains
+    the block-averaged cross spectra
+
+    ``FFT[rho_A(Q,t)] * conj(FFT[rho_B(Q,t)))``.
+
+    ``weighted_total`` is the coherent spectrum reconstructed from the partials
+    using the supplied species weights.
+    """
+
+    positions = np.asarray(positions, dtype=float)
+    if positions.ndim != 3 or positions.shape[2] != 3:
+        raise ValueError("positions must have shape (num_frames, num_atoms, 3)")
+    qpoints = np.atleast_2d(np.asarray(qpoints_cartesian, dtype=float))
+    if qpoints.shape[1] != 3:
+        raise ValueError("qpoints_cartesian must have shape (num_qpoints, 3)")
+
+    n_frames, n_atoms, _ = positions.shape
+    atom_types = np.asarray(atom_types)
+    if atom_types.shape[0] != n_atoms:
+        raise ValueError("atom_types length must match number of atoms")
+
+    kernel = resolve_backend(backend)
+    xp = kernel.xp
+    species, groups = _species_groups(atom_types)
+    n_species = len(species)
+    blocks = as_blocks(n_frames, num_blocks)
+    block_size = blocks[0][1] - blocks[0][0]
+    grid = frequency_grid(block_size, dt, positive_only=positive_only, backend=kernel)
+    freq_slice = grid.freq_slice
+    freq_out = grid.frequencies_thz
+
+    n_q = qpoints.shape[0]
+    n_f = len(freq_out)
+    partial_blocks = np.zeros((num_blocks, n_q, n_species, n_species, n_f), dtype=complex)
+    weighted_total_blocks = np.zeros((num_blocks, n_q, n_f), dtype=float)
+    block_norm = float(block_size * n_atoms)
+
+    for block_index, (start, stop) in enumerate(blocks):
+        block = positions[start:stop]
+        for q_index, q_vec in enumerate(qpoints):
+            phase = phase_factors(block, q_vec, backend=kernel)
+            rho_species = xp.zeros((block_size, n_species), dtype=complex)
+            for species_index, atom_ids in enumerate(groups):
+                rho_species[:, species_index] = xp.sum(
+                    phase[:, xp.asarray(atom_ids)],
+                    axis=1,
+                )
+
+            rho_fft = kernel.fft(rho_species, axis=0, norm="forward")[freq_slice]
+            partial = xp.einsum("fa,fb->abf", rho_fft, xp.conjugate(rho_fft)) / block_norm
+            partial_np = to_numpy(partial, kernel)
+            partial_blocks[block_index, q_index] = partial_np
+
+            weights = _species_weights_for_q(species_weights, species, q_index)
+            weighted = np.einsum("a,abf,b->f", weights, partial_np, np.conjugate(weights))
+            weighted_total_blocks[block_index, q_index] = weighted.real
+
+    partial_mean = np.mean(partial_blocks, axis=0)
+    partial_sem = np.std(partial_blocks, axis=0, ddof=1) / np.sqrt(num_blocks) if num_blocks > 1 else np.zeros_like(partial_mean, dtype=float)
+    weighted_total = np.mean(weighted_total_blocks, axis=0)
+    weighted_total_sem = standard_error(weighted_total_blocks)
+
+    return PartialDSFResult(
+        qpoints_cartesian=qpoints,
+        frequencies_thz=freq_out,
+        species=species,
+        partial=partial_mean,
+        partial_sem=partial_sem,
+        weighted_total=weighted_total,
+        weighted_total_sem=weighted_total_sem,
+        num_blocks=num_blocks,
+        metadata={
+            "dt_seconds": float(dt),
+            "positive_only": bool(positive_only),
+            "backend": kernel.name,
+            "normalization": "block spectra divided by block_size * num_atoms, then averaged",
+            "species_weights": "unit weights" if species_weights is None else "user supplied",
+        },
+    )
+
+
+def compute_coherent_dsf_via_correlation(
+    positions,
+    qpoints_cartesian,
+    dt,
+    coherent_weights=None,
+    num_blocks=1,
+    positive_only=True,
+    backend="cpu",
+):
+    """Reference coherent DSF from the density autocorrelation function.
+
+    This routine is intentionally more explicit and slower than
+    :func:`compute_dsf`.  It first constructs the finite-block circular
+    intermediate scattering function
+
+    ``F(Q, lag) = mean_t rho(Q, t + lag) rho(Q, t).conjugate()``
+
+    and then Fourier transforms ``F`` in time.  It is mainly useful for
+    validating that the production estimator based on
+    ``abs(FFT_t[rho(Q, t)])**2`` is consistent with the correlation-function
+    formulation.
+    """
+
+    positions = np.asarray(positions, dtype=float)
+    if positions.ndim != 3 or positions.shape[2] != 3:
+        raise ValueError("positions must have shape (num_frames, num_atoms, 3)")
+    qpoints = np.atleast_2d(np.asarray(qpoints_cartesian, dtype=float))
+    if qpoints.shape[1] != 3:
+        raise ValueError("qpoints_cartesian must have shape (num_qpoints, 3)")
+    kernel = resolve_backend(backend)
+    xp = kernel.xp
+
+    n_frames, n_atoms, _ = positions.shape
+    blocks = as_blocks(n_frames, num_blocks)
+    block_size = blocks[0][1] - blocks[0][0]
+    grid = frequency_grid(block_size, dt, positive_only=positive_only, backend=kernel)
+    freq_slice = grid.freq_slice
+    freq_out = grid.frequencies_thz
+
+    n_q = qpoints.shape[0]
+    n_f = len(freq_out)
+    coherent_blocks = np.zeros((num_blocks, n_q, n_f), dtype=float)
+    elastic_blocks = np.zeros((num_blocks, n_q), dtype=float)
+    block_norm = float(block_size * n_atoms)
+
+    for block_index, (start, stop) in enumerate(blocks):
+        block = positions[start:stop]
+        for q_index, q_vec in enumerate(qpoints):
+            w = _weights_for_q(coherent_weights, q_index, n_atoms)
+            rho = density_amplitude(block, q_vec, w, backend=kernel)
+            elastic_blocks[block_index, q_index] = (
+                to_numpy(xp.abs(xp.mean(rho)) ** 2, kernel) / block_norm
+            )
+
+            correlation = circular_autocorrelation(rho, backend=kernel)
+            spectrum = kernel.fft(correlation, norm="forward").real
+            coherent_blocks[block_index, q_index] = (
+                to_numpy(spectrum[freq_slice], kernel) / block_norm
+            )
+
+    coherent = np.mean(coherent_blocks, axis=0)
+    zeros = np.zeros_like(coherent)
+    elastic = np.mean(elastic_blocks, axis=0)
+    elastic_zeros = np.zeros_like(elastic)
+    coherent_sem = standard_error(coherent_blocks)
+
+    return DSFResult(
+        qpoints_cartesian=qpoints,
+        frequencies_thz=freq_out,
+        coherent=coherent,
+        incoherent=zeros,
+        total=coherent,
+        elastic_coherent=elastic,
+        elastic_incoherent=elastic_zeros,
+        num_blocks=num_blocks,
+        metadata={
+            "experiment": "custom",
+            "dt_seconds": float(dt),
+            "positive_only": bool(positive_only),
+            "backend": kernel.name,
+            "estimator": "circular density autocorrelation followed by time FFT",
+            "normalization": "block spectra divided by block_size * num_atoms, then averaged",
+            "uncertainty": "standard error of the block-averaged spectra",
+        },
+        coherent_sem=coherent_sem,
+        incoherent_sem=zeros,
+        total_sem=coherent_sem,
+        elastic_coherent_sem=standard_error(elastic_blocks),
+        elastic_incoherent_sem=elastic_zeros,
+    )
+
+
+def compute_current_correlations(
+    positions,
+    velocities,
+    qpoints_cartesian,
+    dt,
+    weights=None,
+    num_blocks=1,
+    positive_only=True,
+    backend="cpu",
+):
+    """Compute longitudinal and transverse current spectra.
+
+    Spectra are evaluated independently for each time block, normalized by
+    ``block_size * num_atoms``, then averaged.  When ``num_blocks > 1``, the
+    result includes standard errors of the block-averaged spectra.
+    """
+
+    positions = np.asarray(positions, dtype=float)
+    velocities = np.asarray(velocities, dtype=float)
+    qpoints = np.atleast_2d(np.asarray(qpoints_cartesian, dtype=float))
+    if positions.shape != velocities.shape:
+        raise ValueError("positions and velocities must have identical shape")
+    if positions.ndim != 3 or positions.shape[2] != 3:
+        raise ValueError("positions must have shape (num_frames, num_atoms, 3)")
+    kernel = resolve_backend(backend)
+    xp = kernel.xp
+
+    n_frames, n_atoms, _ = positions.shape
+    blocks = as_blocks(n_frames, num_blocks)
+    block_size = blocks[0][1] - blocks[0][0]
+    grid = frequency_grid(block_size, dt, positive_only=positive_only, backend=kernel)
+    freq_slice = grid.freq_slice
+    freq_out = grid.frequencies_thz
+
+    n_q = qpoints.shape[0]
+    n_f = len(freq_out)
+    longitudinal_blocks = np.zeros((num_blocks, n_q, n_f), dtype=float)
+    transverse_blocks = np.zeros_like(longitudinal_blocks)
+
+    block_norm = float(block_size * n_atoms)
+    for block_index, (start, stop) in enumerate(blocks):
+        pos_block = positions[start:stop]
+        vel_block = velocities[start:stop]
+        for q_index, q_vec in enumerate(qpoints):
+            q_norm = np.linalg.norm(q_vec)
+            if q_norm == 0:
+                continue
+            q_hat = xp.asarray(q_vec / q_norm)
+            phase = phase_factors(pos_block, q_vec, backend=kernel)
+            w = xp.asarray(_weights_for_q(weights, q_index, n_atoms))
+            weighted_phase = phase * w.reshape(1, -1)
+            vel_backend = xp.asarray(vel_block, dtype=float)
+
+            v_long = xp.tensordot(vel_backend, q_hat, axes=([2], [0]))
+            j_long = xp.sum(weighted_phase * v_long, axis=1)
+            long_spec = fft_power(j_long, norm="forward", backend=kernel)
+            longitudinal_blocks[block_index, q_index] = (
+                to_numpy(long_spec[freq_slice].real, kernel) / block_norm
+            )
+
+            v_long_vec = v_long[:, :, None] * q_hat.reshape(1, 1, 3)
+            v_trans = vel_backend - v_long_vec
+            j_trans = xp.sum(weighted_phase[:, :, None] * v_trans, axis=1)
+            trans_spec = xp.sum(fft_power(j_trans, axis=0, norm="forward", backend=kernel), axis=1)
+            transverse_blocks[block_index, q_index] = (
+                to_numpy(trans_spec[freq_slice].real, kernel) / block_norm
+            )
+
+    return CurrentCorrelationResult(
+        qpoints_cartesian=qpoints,
+        frequencies_thz=freq_out,
+        longitudinal=np.mean(longitudinal_blocks, axis=0),
+        transverse=np.mean(transverse_blocks, axis=0),
+        num_blocks=num_blocks,
+        longitudinal_sem=standard_error(longitudinal_blocks),
+        transverse_sem=standard_error(transverse_blocks),
+        metadata={
+            "dt_seconds": float(dt),
+            "positive_only": bool(positive_only),
+            "backend": kernel.name,
+            "normalization": "block spectra divided by block_size * num_atoms, then averaged",
+            "uncertainty": "standard error of the block-averaged spectra",
+        },
+    )

--- a/pySED/eels.py
+++ b/pySED/eels.py
@@ -1,0 +1,465 @@
+"""Kinematic q-EELS visibility and map construction."""
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from pySED.probe_weights import electron_form_factor_weights
+from pySED.q_advisor import reciprocal_lattice, wrap_reduced
+
+
+@dataclass
+class EELSVisibility:
+    qpoints_reduced: np.ndarray
+    g_vectors_reduced: np.ndarray
+    Q_reduced: np.ndarray
+    Q_cartesian: np.ndarray
+    visibility: np.ndarray
+    metadata: dict
+
+
+@dataclass
+class EELSMap:
+    Q_reduced: np.ndarray
+    Q_cartesian: np.ndarray
+    energy_axis: np.ndarray
+    intensity: np.ndarray
+    visibility: np.ndarray
+
+
+@dataclass
+class EELSDecompositionMap:
+    Q_reduced: np.ndarray
+    Q_cartesian: np.ndarray
+    energy_axis: np.ndarray
+    intensity: np.ndarray
+    atom_intensity: np.ndarray
+    direction_intensity: np.ndarray
+    atom_interference_intensity: np.ndarray
+    visibility: np.ndarray
+    atom_visibility: np.ndarray
+    direction_visibility: np.ndarray
+    atom_interference: np.ndarray
+    metadata: dict
+
+
+@dataclass
+class EELSVisibilityDecomposition:
+    qpoints_reduced: np.ndarray
+    g_vectors_reduced: np.ndarray
+    Q_reduced: np.ndarray
+    Q_cartesian: np.ndarray
+    amplitude: np.ndarray
+    visibility: np.ndarray
+    atom_amplitude: np.ndarray
+    atom_visibility: np.ndarray
+    direction_amplitude: np.ndarray
+    direction_visibility: np.ndarray
+    atom_interference: np.ndarray
+    metadata: dict
+
+
+def lorentzian(axis, center, hwhm):
+    axis = np.asarray(axis, dtype=float)
+    return 1.0 / (1.0 + ((axis - center) / hwhm) ** 2)
+
+
+def gaussian(axis, center, sigma):
+    axis = np.asarray(axis, dtype=float)
+    return np.exp(-0.5 * ((axis - center) / sigma) ** 2)
+
+
+def fold_to_first_bz(qpoints_reduced):
+    return wrap_reduced(qpoints_reduced, centered=True)
+
+
+def _form_factors_for_qg(electron_form_factors, i_q, i_g, n_q, n_g, n_basis):
+    if electron_form_factors is None:
+        return np.ones(n_basis, dtype=float)
+
+    form_arr = np.asarray(electron_form_factors, dtype=float)
+    if form_arr.ndim == 1:
+        if form_arr.shape[0] != n_basis:
+            raise ValueError("1D electron_form_factors length must match number of basis atoms")
+        return form_arr
+    if form_arr.ndim == 2:
+        if form_arr.shape == (n_q * n_g, n_basis):
+            return form_arr[i_q * n_g + i_g]
+        if form_arr.shape == (n_q, n_basis):
+            return form_arr[i_q]
+        raise ValueError(
+            "2D electron_form_factors must have shape (num_q*num_g, num_basis) or (num_q, num_basis)"
+        )
+    if form_arr.ndim == 3:
+        if form_arr.shape != (n_q, n_g, n_basis):
+            raise ValueError("3D electron_form_factors must have shape (num_q, num_g, num_basis)")
+        return form_arr[i_q, i_g]
+    raise ValueError("electron_form_factors must be 1D, 2D, or 3D")
+
+
+def _electron_form_factor_array(
+    electron_form_factors,
+    electron_form_factor_model,
+    atom_types,
+    qpoints_cartesian,
+    coefficients_table,
+    missing,
+    n_q,
+    n_g,
+    n_basis,
+):
+    if electron_form_factors is not None:
+        return electron_form_factors, "user supplied"
+
+    model = "unit" if electron_form_factor_model is None else str(electron_form_factor_model).lower()
+    model = model.replace("_", "-")
+    if model in ("unit", "unity", "ones"):
+        return None, "unit"
+    if model not in ("mott-bethe", "mottbethe"):
+        raise ValueError("electron_form_factor_model must be 'unit' or 'mott-bethe'")
+
+    if atom_types is None:
+        raise ValueError("atom_types are required for electron_form_factor_model='mott-bethe'")
+    if len(atom_types) != n_basis:
+        raise ValueError("atom_types length must match number of basis atoms")
+
+    qpoints = np.asarray(qpoints_cartesian, dtype=float).reshape(n_q * n_g, 3)
+    weights = electron_form_factor_weights(
+        atom_types,
+        qpoints,
+        coefficients_table=coefficients_table,
+        missing=missing,
+    )
+    return weights.reshape(n_q, n_g, n_basis), "mott-bethe"
+
+
+def compute_mode_visibility(
+    qpoints_reduced,
+    g_vectors_reduced,
+    primitive_cell,
+    basis_positions_reduced,
+    masses,
+    eigenvectors,
+    electron_form_factors=None,
+    atom_types=None,
+    electron_form_factor_model="unit",
+    electron_form_factor_table=None,
+    electron_missing="raise",
+    pairwise_g_vectors=False,
+):
+    """Compute branch visibility for extended-zone kinematic q-EELS.
+
+    The implemented factor is
+
+        ``abs(sum_b f_b(Q) (Q dot e_bv(q)) exp(i 2*pi Q_red dot tau_b)
+        / sqrt(m_b))**2``.
+    """
+
+    decomposition = compute_mode_visibility_decomposition(
+        qpoints_reduced,
+        g_vectors_reduced,
+        primitive_cell,
+        basis_positions_reduced,
+        masses,
+        eigenvectors,
+        electron_form_factors=electron_form_factors,
+        atom_types=atom_types,
+        electron_form_factor_model=electron_form_factor_model,
+        electron_form_factor_table=electron_form_factor_table,
+        electron_missing=electron_missing,
+        pairwise_g_vectors=pairwise_g_vectors,
+    )
+    return EELSVisibility(
+        qpoints_reduced=decomposition.qpoints_reduced,
+        g_vectors_reduced=decomposition.g_vectors_reduced,
+        Q_reduced=decomposition.Q_reduced,
+        Q_cartesian=decomposition.Q_cartesian,
+        visibility=decomposition.visibility,
+        metadata=decomposition.metadata,
+    )
+
+
+def compute_mode_visibility_decomposition(
+    qpoints_reduced,
+    g_vectors_reduced,
+    primitive_cell,
+    basis_positions_reduced,
+    masses,
+    eigenvectors,
+    electron_form_factors=None,
+    atom_types=None,
+    electron_form_factor_model="unit",
+    electron_form_factor_table=None,
+    electron_missing="raise",
+    pairwise_g_vectors=False,
+):
+    """Compute complex q-EELS visibility contributions.
+
+    The primitive contribution is
+
+    ``A[b, alpha] = f_b(Q) Q_alpha e_balpha(q, nu)
+    exp(i 2*pi Q_red dot tau_b) / sqrt(m_b)``.
+
+    Atom and direction amplitudes are coherent sums of ``A[b, alpha]``.  Their
+    squared magnitudes are diagnostic quantities; they do not add up to the
+    total visibility when there is destructive or constructive interference.
+    """
+
+    qpoints = np.atleast_2d(np.asarray(qpoints_reduced, dtype=float))
+    g_vectors = np.atleast_2d(np.asarray(g_vectors_reduced, dtype=float))
+    basis_pos = np.asarray(basis_positions_reduced, dtype=float)
+    masses = np.asarray(masses, dtype=float)
+    eig = np.asarray(eigenvectors, dtype=complex)
+
+    if eig.shape[0] != qpoints.shape[0]:
+        raise ValueError("eigenvectors first axis must match qpoints")
+    if eig.shape[2:] != (basis_pos.shape[0], 3):
+        raise ValueError("eigenvectors must have shape (num_q, num_modes, num_basis, 3)")
+    if masses.shape[0] != basis_pos.shape[0]:
+        raise ValueError("masses must contain one value per basis atom")
+
+    reciprocal = reciprocal_lattice(primitive_cell)
+    pairwise = bool(pairwise_g_vectors)
+    if pairwise and g_vectors.shape != qpoints.shape:
+        raise ValueError("pairwise g_vectors must have the same shape as qpoints")
+    n_q = qpoints.shape[0]
+    n_g = 1 if pairwise else g_vectors.shape[0]
+    n_modes = eig.shape[1]
+    n_basis = basis_pos.shape[0]
+    Q_red = np.zeros((n_q, n_g, 3), dtype=float)
+    Q_cart = np.zeros_like(Q_red)
+    visibility = np.zeros((n_q, n_g, n_modes), dtype=float)
+    amplitude = np.zeros((n_q, n_g, n_modes), dtype=complex)
+    atom_amplitude = np.zeros((n_q, n_g, n_modes, n_basis), dtype=complex)
+    direction_amplitude = np.zeros((n_q, n_g, n_modes, 3), dtype=complex)
+
+    for i_q, q_red in enumerate(qpoints):
+        active_g_vectors = g_vectors[i_q:i_q + 1] if pairwise else g_vectors
+        for i_g, g_red in enumerate(active_g_vectors):
+            big_q = q_red + g_red
+            big_Q_cart = big_q @ reciprocal
+            Q_red[i_q, i_g] = big_q
+            Q_cart[i_q, i_g] = big_Q_cart
+
+    electron_form_factor_data, electron_model = _electron_form_factor_array(
+        electron_form_factors,
+        electron_form_factor_model,
+        atom_types,
+        Q_cart,
+        electron_form_factor_table,
+        electron_missing,
+        n_q,
+        n_g,
+        n_basis,
+    )
+
+    for i_q, q_red in enumerate(qpoints):
+        active_g_vectors = g_vectors[i_q:i_q + 1] if pairwise else g_vectors
+        for i_g, g_red in enumerate(active_g_vectors):
+            big_q = q_red + g_red
+            big_Q_cart = Q_cart[i_q, i_g]
+            phase = np.exp(2j * np.pi * (basis_pos @ big_q))
+            form = _form_factors_for_qg(
+                electron_form_factor_data,
+                i_q,
+                i_g,
+                n_q,
+                n_g,
+                n_basis,
+            )
+
+            prefactor = form * phase / np.sqrt(masses)
+            component = eig[i_q] * big_Q_cart.reshape(1, 1, 3)
+            contribution = component * prefactor.reshape(1, n_basis, 1)
+            atom_amp = np.sum(contribution, axis=2)
+            direction_amp = np.sum(contribution, axis=1)
+            total_amp = np.sum(atom_amp, axis=1)
+            atom_amplitude[i_q, i_g] = atom_amp
+            direction_amplitude[i_q, i_g] = direction_amp
+            amplitude[i_q, i_g] = total_amp
+            visibility[i_q, i_g] = np.abs(total_amp) ** 2
+
+    atom_visibility = np.abs(atom_amplitude) ** 2
+    direction_visibility = np.abs(direction_amplitude) ** 2
+    atom_interference = visibility - np.sum(atom_visibility, axis=3)
+
+    return EELSVisibilityDecomposition(
+        qpoints_reduced=qpoints,
+        g_vectors_reduced=g_vectors,
+        Q_reduced=Q_red,
+        Q_cartesian=Q_cart,
+        amplitude=amplitude,
+        visibility=visibility,
+        atom_amplitude=atom_amplitude,
+        atom_visibility=atom_visibility,
+        direction_amplitude=direction_amplitude,
+        direction_visibility=direction_visibility,
+        atom_interference=atom_interference,
+        metadata={
+            "model": "kinematic one-phonon visibility",
+            "extended_zone": "Q = q + G",
+            "electron_form_factor_model": electron_model,
+            "pairwise_g_vectors": pairwise,
+            "decomposition": "complex amplitudes; diagnostic intensities are not additive under interference",
+        },
+    )
+
+
+def compute_mode_visibility_for_q_path(
+    qpoints_reduced,
+    g_vectors_reduced,
+    primitive_cell,
+    basis_positions_reduced,
+    masses,
+    eigenvectors,
+    electron_form_factors=None,
+    atom_types=None,
+    electron_form_factor_model="unit",
+    electron_form_factor_table=None,
+    electron_missing="raise",
+):
+    """Compute EELS visibility for a pairwise experimental path.
+
+    Unlike :func:`compute_mode_visibility`, this function interprets
+    ``qpoints_reduced[i]`` and ``g_vectors_reduced[i]`` as one experimental
+    point ``Q_i = q_i + G_i``.  The returned visibility has shape
+    ``(num_points, 1, num_modes)`` so it remains compatible with
+    :func:`build_eels_map_from_mode_spectra` without creating the full
+    q-by-G Cartesian product.
+    """
+
+    return compute_mode_visibility(
+        qpoints_reduced,
+        g_vectors_reduced,
+        primitive_cell,
+        basis_positions_reduced,
+        masses,
+        eigenvectors,
+        electron_form_factors=electron_form_factors,
+        atom_types=atom_types,
+        electron_form_factor_model=electron_form_factor_model,
+        electron_form_factor_table=electron_form_factor_table,
+        electron_missing=electron_missing,
+        pairwise_g_vectors=True,
+    )
+
+
+def build_eels_map(
+    visibility,
+    mode_frequencies,
+    energy_axis,
+    broadening,
+    broadening_kind="lorentzian",
+):
+    """Convert mode visibility into an energy-resolved q-EELS map."""
+
+    mode_freq = np.asarray(mode_frequencies, dtype=float)
+    energy = np.asarray(energy_axis, dtype=float)
+    vis = visibility.visibility
+    if mode_freq.shape != vis.shape[:1] + vis.shape[2:]:
+        if mode_freq.shape == (vis.shape[0], vis.shape[2]):
+            pass
+        else:
+            raise ValueError("mode_frequencies must have shape (num_q, num_modes)")
+
+    intensity = np.zeros((vis.shape[0], vis.shape[1], energy.size), dtype=float)
+    for i_q in range(vis.shape[0]):
+        for i_g in range(vis.shape[1]):
+            for mode in range(vis.shape[2]):
+                center = mode_freq[i_q, mode]
+                if broadening_kind == "lorentzian":
+                    profile = lorentzian(energy, center, broadening)
+                elif broadening_kind == "gaussian":
+                    profile = gaussian(energy, center, broadening)
+                else:
+                    raise ValueError("broadening_kind must be 'lorentzian' or 'gaussian'")
+                intensity[i_q, i_g] += vis[i_q, i_g, mode] * profile
+
+    return EELSMap(
+        Q_reduced=visibility.Q_reduced,
+        Q_cartesian=visibility.Q_cartesian,
+        energy_axis=energy,
+        intensity=intensity,
+        visibility=vis,
+    )
+
+
+def build_eels_map_from_mode_spectra(visibility, mode_spectra, energy_axis):
+    """Weight branch-resolved spectral functions into an EELS intensity map.
+
+    ``mode_spectra`` must have shape ``(num_energy, num_q, num_modes)``.  This
+    matches :attr:`pySED.eigen_sed.EigenSEDResult.sed`, allowing branch-resolved
+    MD spectra to be converted directly into extended-zone q-EELS maps:
+
+    ``I(Q, energy) = sum_mode visibility(Q, mode) * A(q, mode, energy)``.
+    """
+
+    vis = np.asarray(visibility.visibility, dtype=float)
+    spectra = np.asarray(mode_spectra, dtype=float)
+    energy = np.asarray(energy_axis, dtype=float)
+
+    if spectra.ndim != 3:
+        raise ValueError("mode_spectra must have shape (num_energy, num_q, num_modes)")
+    if spectra.shape[0] != energy.size:
+        raise ValueError("energy_axis length must match mode_spectra first dimension")
+    if spectra.shape[1:] != (vis.shape[0], vis.shape[2]):
+        raise ValueError("mode_spectra must have shape (num_energy, num_q, num_modes)")
+
+    intensity = np.einsum("qgm,eqm->qge", vis, spectra)
+
+    return EELSMap(
+        Q_reduced=visibility.Q_reduced,
+        Q_cartesian=visibility.Q_cartesian,
+        energy_axis=energy,
+        intensity=intensity,
+        visibility=vis,
+    )
+
+
+def build_eels_decomposition_map_from_mode_spectra(decomposition, mode_spectra, energy_axis):
+    """Convert mode-resolved EELS diagnostics into energy-resolved maps.
+
+    ``decomposition`` should come from
+    :func:`compute_mode_visibility_decomposition`.  The returned maps preserve
+    the non-additive diagnostics:
+
+    ``total = sum_atom(atom_intensity) + atom_interference_intensity``.
+    """
+
+    vis = np.asarray(decomposition.visibility, dtype=float)
+    atom_vis = np.asarray(decomposition.atom_visibility, dtype=float)
+    direction_vis = np.asarray(decomposition.direction_visibility, dtype=float)
+    atom_interference = np.asarray(decomposition.atom_interference, dtype=float)
+    spectra = np.asarray(mode_spectra, dtype=float)
+    energy = np.asarray(energy_axis, dtype=float)
+
+    if spectra.ndim != 3:
+        raise ValueError("mode_spectra must have shape (num_energy, num_q, num_modes)")
+    if spectra.shape[0] != energy.size:
+        raise ValueError("energy_axis length must match mode_spectra first dimension")
+    if spectra.shape[1:] != (vis.shape[0], vis.shape[2]):
+        raise ValueError("mode_spectra must have shape (num_energy, num_q, num_modes)")
+
+    intensity = np.einsum("qgm,eqm->qge", vis, spectra)
+    atom_intensity = np.einsum("qgmb,eqm->qgbe", atom_vis, spectra)
+    direction_intensity = np.einsum("qgmd,eqm->qgde", direction_vis, spectra)
+    atom_interference_intensity = np.einsum("qgm,eqm->qge", atom_interference, spectra)
+
+    return EELSDecompositionMap(
+        Q_reduced=decomposition.Q_reduced,
+        Q_cartesian=decomposition.Q_cartesian,
+        energy_axis=energy,
+        intensity=intensity,
+        atom_intensity=atom_intensity,
+        direction_intensity=direction_intensity,
+        atom_interference_intensity=atom_interference_intensity,
+        visibility=vis,
+        atom_visibility=atom_vis,
+        direction_visibility=direction_vis,
+        atom_interference=atom_interference,
+        metadata={
+            "source": "branch-resolved mode spectra",
+            "decomposition": "diagnostic atom/direction maps; atom terms are not additive without interference",
+            **decomposition.metadata,
+        },
+    )

--- a/pySED/eigen_sed.py
+++ b/pySED/eigen_sed.py
@@ -1,0 +1,193 @@
+"""Eigenvector-resolved spectral energy density."""
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from pySED.q_advisor import QAdvisor
+from pySED.scattering_kernel import frequency_grid, resolve_backend, to_numpy
+
+
+@dataclass
+class EigenvectorSet:
+    qpoints_reduced: np.ndarray
+    frequencies: np.ndarray
+    eigenvectors: np.ndarray
+    source: str = "unknown"
+
+
+@dataclass
+class EigenSEDResult:
+    frequencies_thz: np.ndarray
+    qpoints_reduced: np.ndarray
+    sed: np.ndarray
+    mode_frequencies: np.ndarray
+    metadata: dict
+
+
+def read_phonopy_band_yaml(path):
+    """Read q points, frequencies, and eigenvectors from a phonopy band.yaml."""
+
+    try:
+        import yaml
+    except ImportError as exc:
+        raise ImportError("PyYAML is required to read phonopy band.yaml files") from exc
+
+    with open(path, "r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+
+    phonons = data.get("phonon", [])
+    qpoints = []
+    frequencies = []
+    eigenvectors = []
+    for phonon in phonons:
+        qpoints.append(phonon["q-position"])
+        mode_freqs = []
+        mode_eigs = []
+        for band in phonon["band"]:
+            mode_freqs.append(band.get("frequency", np.nan))
+            eig = []
+            for atom in band["eigenvector"]:
+                atom_vec = []
+                for component in atom:
+                    atom_vec.append(complex(component[0], component[1]))
+                eig.append(atom_vec)
+            mode_eigs.append(eig)
+        frequencies.append(mode_freqs)
+        eigenvectors.append(mode_eigs)
+
+    return EigenvectorSet(
+        qpoints_reduced=np.asarray(qpoints, dtype=float),
+        frequencies=np.asarray(frequencies, dtype=float),
+        eigenvectors=np.asarray(eigenvectors, dtype=complex),
+        source=str(path),
+    )
+
+
+def validate_eigenvector_qpoints(eigenvectors, advisor, target_qpoints=None, atol=1e-6):
+    qpoints = np.asarray(eigenvectors.qpoints_reduced, dtype=float)
+    if not advisor.validate_qpoints(qpoints, atol=atol):
+        raise ValueError("eigenvector q points are not commensurate with the MD supercell")
+
+    if target_qpoints is not None:
+        target = np.asarray(target_qpoints, dtype=float)
+        if target.shape != qpoints.shape:
+            raise ValueError("target q points and eigenvector q points have different shapes")
+        delta = qpoints - target
+        delta -= np.round(delta)
+        if not np.allclose(delta, 0.0, atol=atol):
+            raise ValueError("eigenvector q points do not match the requested pySED q points")
+    return True
+
+
+def _basis_atom_ids_from_index(basis_index):
+    basis_index = np.asarray(basis_index, dtype=int)
+    labels = np.unique(basis_index)
+    if not np.array_equal(labels, np.arange(1, labels.size + 1)):
+        raise ValueError("basis_index must use contiguous one-based labels")
+    groups = [np.flatnonzero(basis_index == label) for label in labels]
+    lengths = {len(group) for group in groups}
+    if len(lengths) != 1:
+        raise ValueError("each basis atom must appear once in every unit cell")
+    return np.asarray(groups, dtype=int)
+
+
+def compute_eigen_sed(
+    velocities,
+    unitcell_vectors,
+    basis_index,
+    masses,
+    primitive_cell,
+    supercell_cell,
+    eigenvectors,
+    dt,
+    num_blocks=1,
+    target_qpoints=None,
+    validate_q=True,
+    backend="cpu",
+):
+    """Project velocities onto phonon eigenvectors and compute branch SED.
+
+    ``velocities`` must have shape ``(num_frames, num_atoms, 3)``.  The
+    ``basis_index`` array maps each atom to a one-based primitive basis label.
+    ``unitcell_vectors`` must contain the equilibrium cell-vector position of
+    each repeated primitive cell in Angstrom.
+    """
+
+    velocities = np.asarray(velocities, dtype=float)
+    unitcell_vectors = np.asarray(unitcell_vectors, dtype=float)
+    basis_ids = _basis_atom_ids_from_index(basis_index)
+    masses = np.asarray(masses, dtype=float)
+    kernel = resolve_backend(backend)
+    xp = kernel.xp
+
+    if velocities.ndim != 3 or velocities.shape[2] != 3:
+        raise ValueError("velocities must have shape (num_frames, num_atoms, 3)")
+    if masses.shape[0] != basis_ids.shape[0]:
+        raise ValueError("masses must contain one value per basis atom")
+    if unitcell_vectors.shape != (basis_ids.shape[1], 3):
+        raise ValueError("unitcell_vectors must have shape (num_unit_cells, 3)")
+
+    advisor = QAdvisor(primitive_cell, supercell_cell)
+    if validate_q:
+        validate_eigenvector_qpoints(eigenvectors, advisor, target_qpoints=target_qpoints)
+
+    qpoints_red = np.asarray(eigenvectors.qpoints_reduced, dtype=float)
+    qpoints_cart = advisor.reduced_to_cartesian(qpoints_red)
+    eig = np.asarray(eigenvectors.eigenvectors, dtype=complex)
+    if eig.shape[:1] != (qpoints_red.shape[0],):
+        raise ValueError("eigenvectors first axis must match qpoints")
+    if eig.shape[2:] != (basis_ids.shape[0], 3):
+        raise ValueError("eigenvectors must have shape (num_q, num_modes, num_basis, 3)")
+
+    n_frames = velocities.shape[0]
+    block_size = n_frames // num_blocks
+    if block_size < 2:
+        raise ValueError("each block must contain at least two frames")
+    grid = frequency_grid(block_size, dt, positive_only=True, backend=kernel)
+    pos_slice = grid.freq_slice
+    freq_out = grid.frequencies_thz
+
+    n_q, n_modes = eig.shape[0], eig.shape[1]
+    sed = xp.zeros((len(freq_out), n_q, n_modes), dtype=float)
+
+    velocities_backend = xp.asarray(velocities, dtype=float)
+    unitcell_vectors_backend = xp.asarray(unitcell_vectors, dtype=float)
+    qpoints_cart_backend = xp.asarray(qpoints_cart, dtype=float)
+    eig_backend = xp.asarray(eig, dtype=complex)
+    sqrt_m = xp.sqrt(xp.asarray(masses, dtype=float))
+    for block in range(num_blocks):
+        start = block * block_size
+        stop = start + block_size
+        vel_block = velocities_backend[start:stop]
+
+        for q_index, q_cart in enumerate(qpoints_cart):
+            q_cart_backend = qpoints_cart_backend[q_index]
+            phase = xp.exp(1j * (unitcell_vectors_backend @ q_cart_backend))
+            basis_fft_inputs = xp.zeros((block_size, basis_ids.shape[0], 3), dtype=complex)
+            for b_idx, atom_ids in enumerate(basis_ids):
+                basis_vel = vel_block[:, atom_ids, :]
+                phased = basis_vel * phase.reshape(1, -1, 1)
+                basis_fft_inputs[:, b_idx, :] = xp.sum(phased, axis=1) * sqrt_m[b_idx]
+
+            projected = xp.einsum(
+                "tba,mba->tm",
+                basis_fft_inputs,
+                xp.conjugate(eig_backend[q_index]),
+            )
+            spectrum = xp.abs(kernel.fft(projected, axis=0)) ** 2
+            sed[:, q_index, :] += xp.real(spectrum[pos_slice])
+
+    sed = to_numpy(sed / float(num_blocks), kernel)
+    return EigenSEDResult(
+        frequencies_thz=freq_out,
+        qpoints_reduced=qpoints_red,
+        sed=sed,
+        mode_frequencies=np.asarray(eigenvectors.frequencies, dtype=float),
+        metadata={
+            "dt_seconds": float(dt),
+            "num_blocks": int(num_blocks),
+            "backend": kernel.name,
+            "normalization": "branch projected |FFT(qdot)|^2 averaged over blocks",
+        },
+    )

--- a/pySED/electron_kinematics.py
+++ b/pySED/electron_kinematics.py
@@ -1,0 +1,146 @@
+"""Electron-beam kinematics for calibrating q-EELS momentum axes."""
+
+import numpy as np
+
+
+ELECTRON_REST_ENERGY_EV = 510998.95000
+HC_EV_ANGSTROM = 12398.419843320026
+HBAR_C_EV_ANGSTROM = 1973.269804593025
+
+
+def _positive_energy(value, name):
+    value = float(value)
+    if value <= 0.0:
+        raise ValueError("%s must be positive" % name)
+    return value
+
+
+def electron_momentum_pc_ev(beam_energy_ev):
+    """Return relativistic electron momentum times c in eV."""
+
+    kinetic = _positive_energy(beam_energy_ev, "beam_energy_ev")
+    return float(np.sqrt(kinetic * (kinetic + 2.0 * ELECTRON_REST_ENERGY_EV)))
+
+
+def electron_wavelength_angstrom(beam_energy_ev):
+    """Return relativistic de Broglie wavelength in Angstrom."""
+
+    return HC_EV_ANGSTROM / electron_momentum_pc_ev(beam_energy_ev)
+
+
+def electron_wavenumber_per_angstrom(beam_energy_ev):
+    """Return electron wave number ``2*pi/lambda`` in inverse Angstrom."""
+
+    return 2.0 * np.pi / electron_wavelength_angstrom(beam_energy_ev)
+
+
+def electron_beta(beam_energy_ev):
+    """Return relativistic electron speed as ``v/c``."""
+
+    kinetic = _positive_energy(beam_energy_ev, "beam_energy_ev")
+    pc = electron_momentum_pc_ev(kinetic)
+    return pc / (kinetic + ELECTRON_REST_ENERGY_EV)
+
+
+def longitudinal_momentum_transfer(energy_loss_ev, beam_energy_ev):
+    """Return the small-loss longitudinal momentum transfer in inverse Angstrom.
+
+    The approximation is ``q_parallel = DeltaE / (hbar v)`` with
+    ``v = beta c``.  For vibrational losses this term is usually much smaller
+    than the transverse detector momentum but it is useful for documenting the
+    experiment geometry.
+    """
+
+    loss = np.asarray(energy_loss_ev, dtype=float)
+    beta = electron_beta(beam_energy_ev)
+    return loss / (HBAR_C_EV_ANGSTROM * beta)
+
+
+def _angle_scale(unit):
+    key = str(unit).lower()
+    if key in ("rad", "radian", "radians"):
+        return 1.0
+    if key in ("mrad", "milliradian", "milliradians"):
+        return 1.0e-3
+    if key in ("degree", "degrees", "deg"):
+        return np.pi / 180.0
+    raise ValueError("angle_unit must be 'rad', 'mrad', or 'degree'")
+
+
+def scattering_angles_to_qpoints(
+    theta_x,
+    theta_y=None,
+    beam_energy_ev=200000.0,
+    energy_loss_ev=0.0,
+    angle_unit="rad",
+    include_longitudinal=True,
+):
+    """Convert small electron scattering angles to Cartesian Q points.
+
+    ``theta_x`` and ``theta_y`` are detector scattering angles.  The transverse
+    momentum transfer is reported with the experimental sign convention
+    ``Q_perp = k0 * theta`` where ``k0 = 2*pi/lambda``.  If
+    ``include_longitudinal`` is true, the third component is
+    ``DeltaE / (hbar v)``; otherwise it is zero.
+    """
+
+    theta_x = np.asarray(theta_x, dtype=float)
+    if theta_y is None:
+        theta_y = np.zeros_like(theta_x)
+    theta_y = np.asarray(theta_y, dtype=float)
+    theta_x, theta_y = np.broadcast_arrays(theta_x, theta_y)
+    scale = _angle_scale(angle_unit)
+    theta_x_rad = theta_x * scale
+    theta_y_rad = theta_y * scale
+    k0 = electron_wavenumber_per_angstrom(beam_energy_ev)
+
+    q_z = np.zeros_like(theta_x_rad, dtype=float)
+    if include_longitudinal:
+        q_z = np.broadcast_to(
+            longitudinal_momentum_transfer(energy_loss_ev, beam_energy_ev),
+            theta_x_rad.shape,
+        ).astype(float)
+
+    return np.stack((k0 * theta_x_rad, k0 * theta_y_rad, q_z), axis=-1)
+
+
+def eels_qpoints_from_angle_axis(
+    angle_axis,
+    beam_energy_ev,
+    direction=(1.0, 0.0),
+    energy_loss_ev=0.0,
+    angle_unit="mrad",
+    include_longitudinal=False,
+):
+    """Return a q-EELS line-scan Q path from a scalar scattering-angle axis."""
+
+    axis = np.asarray(angle_axis, dtype=float)
+    if axis.ndim != 1:
+        raise ValueError("angle_axis must be one-dimensional")
+    direction = np.asarray(direction, dtype=float)
+    if direction.shape != (2,):
+        raise ValueError("direction must contain two transverse components")
+    norm = float(np.linalg.norm(direction))
+    if norm == 0.0:
+        raise ValueError("direction must be nonzero")
+    direction = direction / norm
+    return scattering_angles_to_qpoints(
+        theta_x=axis * direction[0],
+        theta_y=axis * direction[1],
+        beam_energy_ev=beam_energy_ev,
+        energy_loss_ev=energy_loss_ev,
+        angle_unit=angle_unit,
+        include_longitudinal=include_longitudinal,
+    )
+
+
+def angular_resolution_to_q_sigma(sigma_angle, beam_energy_ev, angle_unit="mrad"):
+    """Convert an angular resolution width to transverse ``sigma_q``.
+
+    The returned value is in inverse Angstrom and can be passed to
+    :func:`pySED.compare_experiment.prepare_map_comparison` as ``sigma_q`` when
+    the scattering-map q axis is a Cartesian path distance in inverse Angstrom.
+    """
+
+    sigma = abs(float(sigma_angle)) * _angle_scale(angle_unit)
+    return electron_wavenumber_per_angstrom(beam_energy_ev) * sigma

--- a/pySED/main.py
+++ b/pySED/main.py
@@ -118,6 +118,17 @@ def main():
         q_path_name             : Name of q-path. Default='GA'. Tips: for gaphene, one can set q_path_name = 'GMKG'.
         q_path                  : Q-points in fractional coordinates. Tips: for q_path = 'GA', q_path = 0.0 0.0 0.0  0.5 0.0 0.0.
 
+    [ Scattering / Q-advisor ]
+        scattering              : Enable experiment-facing scattering mode (1=yes, 0=no). Default = 0.
+        scattering_mode         : Input-file mode. Currently supports 'q_advisor'.
+        scattering_qpoints_option : Q source: 'path', 'mesh', 'file', or 'points'. Default = 'path'.
+        scattering_qpoint_coordinates : 'reduced' or 'cartesian'. Default = 'reduced'.
+        scattering_q_policy     : 'strict' rejects non-commensurate Q; 'nearest' maps to nearest allowed Q.
+        scattering_q_path_steps : Optional points per q_path segment for selected-Q sampling.
+        scattering_q_file       : Text file with one Q point per row when scattering_qpoints_option = file.
+        scattering_q_mesh_H/K/L : Scalar or start stop num mesh axes when scattering_qpoints_option = mesh.
+        scattering_output_prefix: Prefix for q-advisor report files.
+
     ────────────────────────────────────────────────────────────
     [ Plotting Options ]
         plot_SED                : Plot/fitting mode (1) or compute mode (0). Default: plot_SED = 0.
@@ -186,6 +197,33 @@ def main():
 
     ### **************** Read the input parameter file and get the control parameters ******************
     params = My_Parsers.get_parse_input(input_file)
+
+    ## **************** Experiment-facing scattering/q-advisor mode ******************
+    if getattr(params, 'scattering', False):
+        print('\n******************* You are in the Scattering/Q-advisor mode ********************')
+        from pySED.scattering_input import ScatteringInputError, run_scattering_from_input
+        try:
+            scattering_result = run_scattering_from_input(params)
+        except (ScatteringInputError, ValueError) as exc:
+            print('\n**************** ERROR: Scattering input workflow failed ****************')
+            print(str(exc))
+            written_files = getattr(exc, 'written_files', {})
+            if written_files:
+                print('\nPartial q-advisor files were written:')
+                for name, path in written_files.items():
+                    print('  {}: {}'.format(name, path))
+            exit(1)
+
+        report = scattering_result['report']
+        print('\n******** Q-advisor finished: {}/{} Q-points are commensurate ********'
+              .format(report.num_commensurate, report.num_points))
+        print('******** Suggested diagonal supercell: {} ********'
+              .format(report.suggested_diagonal_supercell.tolist()))
+        print('******** Written files ********')
+        for name, path in scattering_result['written_files'].items():
+            print('  {}: {}'.format(name, path))
+        print('\n******* Scattering/Q-advisor mode is done. Use the written nearest or phonopy Q-points for DSF/EELS workflows. *******\n')
+        exit()
 
     ## **************** Select the SED-modes (compute or plot-including-fitting mode) ******************
     if params.plot_SED:

--- a/pySED/mode_visibility.py
+++ b/pySED/mode_visibility.py
@@ -1,0 +1,414 @@
+"""Mode-resolved one-phonon visibility for neutron and X-ray scattering."""
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from pySED.dsf import neutron_weights
+from pySED.probe_weights import xray_form_factor_weights
+from pySED.q_advisor import reciprocal_lattice
+
+
+@dataclass
+class OnePhononVisibility:
+    """Coherent one-phonon mode visibility and diagnostic amplitudes."""
+
+    qpoints_reduced: np.ndarray
+    g_vectors_reduced: np.ndarray
+    Q_reduced: np.ndarray
+    Q_cartesian: np.ndarray
+    amplitude: np.ndarray
+    visibility: np.ndarray
+    atom_amplitude: np.ndarray
+    atom_visibility: np.ndarray
+    direction_amplitude: np.ndarray
+    direction_visibility: np.ndarray
+    atom_interference: np.ndarray
+    scattering_weights: np.ndarray
+    metadata: dict
+
+
+@dataclass
+class OnePhononMap:
+    """Energy-resolved coherent one-phonon visibility map."""
+
+    Q_reduced: np.ndarray
+    Q_cartesian: np.ndarray
+    energy_axis: np.ndarray
+    intensity: np.ndarray
+    visibility: np.ndarray
+    metadata: dict
+
+
+@dataclass
+class OnePhononDecompositionMap:
+    """Energy-resolved atom/direction/interference one-phonon diagnostics."""
+
+    Q_reduced: np.ndarray
+    Q_cartesian: np.ndarray
+    energy_axis: np.ndarray
+    intensity: np.ndarray
+    atom_intensity: np.ndarray
+    direction_intensity: np.ndarray
+    atom_interference_intensity: np.ndarray
+    visibility: np.ndarray
+    atom_visibility: np.ndarray
+    direction_visibility: np.ndarray
+    atom_interference: np.ndarray
+    metadata: dict
+
+
+def lorentzian(axis, center, hwhm):
+    axis = np.asarray(axis, dtype=float)
+    return 1.0 / (1.0 + ((axis - center) / hwhm) ** 2)
+
+
+def gaussian(axis, center, sigma):
+    axis = np.asarray(axis, dtype=float)
+    return np.exp(-0.5 * ((axis - center) / sigma) ** 2)
+
+
+def _coerce_weight_array(weights, n_q, n_g, n_basis):
+    if weights is None:
+        return np.ones((n_q, n_g, n_basis), dtype=float)
+    arr = np.asarray(weights, dtype=float)
+    if arr.ndim == 1:
+        if arr.shape != (n_basis,):
+            raise ValueError("1D scattering_weights length must match number of basis atoms")
+        return np.tile(arr.reshape(1, 1, n_basis), (n_q, n_g, 1))
+    if arr.ndim == 2:
+        if arr.shape == (n_q * n_g, n_basis):
+            return arr.reshape(n_q, n_g, n_basis)
+        if arr.shape == (n_q, n_basis):
+            return np.tile(arr[:, None, :], (1, n_g, 1))
+        raise ValueError(
+            "2D scattering_weights must have shape (num_q*num_g, num_basis) or (num_q, num_basis)"
+        )
+    if arr.ndim == 3:
+        if arr.shape != (n_q, n_g, n_basis):
+            raise ValueError("3D scattering_weights must have shape (num_q, num_g, num_basis)")
+        return arr
+    raise ValueError("scattering_weights must be 1D, 2D, or 3D")
+
+
+def _frequency_scale(mode_frequencies, frequency_power, n_q, n_modes):
+    if frequency_power is None or frequency_power == 0:
+        return np.ones((n_q, n_modes), dtype=float)
+    freq = np.asarray(mode_frequencies, dtype=float)
+    if freq.shape != (n_q, n_modes):
+        raise ValueError("mode_frequencies must have shape (num_q, num_modes)")
+    scale = np.zeros_like(freq, dtype=float)
+    positive = freq > 0.0
+    scale[positive] = freq[positive] ** (0.5 * float(frequency_power))
+    return scale
+
+
+def _resolve_probe_weights(
+    experiment,
+    atom_types,
+    qpoints_cartesian,
+    scattering_weights,
+    n_q,
+    n_g,
+    n_basis,
+    xray_form_factor_table=None,
+    xray_missing="atomic_number",
+):
+    if scattering_weights is not None:
+        return _coerce_weight_array(scattering_weights, n_q, n_g, n_basis), "user supplied"
+
+    experiment_key = str(experiment).lower()
+    if experiment_key == "custom":
+        return _coerce_weight_array(None, n_q, n_g, n_basis), "unit custom weights"
+    if atom_types is None:
+        raise ValueError("atom_types must be supplied for neutron or xray visibility")
+    if len(atom_types) != n_basis:
+        raise ValueError("atom_types length must match number of basis atoms")
+
+    if experiment_key == "neutron":
+        weights, _ = neutron_weights(atom_types, include_incoherent=False)
+        return _coerce_weight_array(weights, n_q, n_g, n_basis), "neutron coherent scattering lengths"
+    if experiment_key == "xray":
+        flat_weights = xray_form_factor_weights(
+            atom_types,
+            qpoints_cartesian=qpoints_cartesian.reshape(-1, 3),
+            coefficients_table=xray_form_factor_table,
+            missing=xray_missing,
+        )
+        return _coerce_weight_array(flat_weights, n_q, n_g, n_basis), "Cromer-Mann X-ray form factors"
+
+    raise ValueError("experiment must be 'neutron', 'xray', or 'custom'")
+
+
+def compute_one_phonon_visibility(
+    qpoints_reduced,
+    g_vectors_reduced,
+    primitive_cell,
+    basis_positions_reduced,
+    masses,
+    eigenvectors,
+    atom_types=None,
+    experiment="neutron",
+    scattering_weights=None,
+    mode_frequencies=None,
+    frequency_power=0,
+    xray_form_factor_table=None,
+    xray_missing="atomic_number",
+    pairwise_g_vectors=False,
+):
+    """Compute coherent one-phonon INS/IXS visibility for each mode.
+
+    The elementary complex contribution is
+
+    ``A[b, alpha] = w_b(Q) Q_alpha e_balpha(q, nu)
+    exp(i 2*pi Q_red dot tau_b) / sqrt(m_b)``.
+
+    ``frequency_power=-1`` adds the common harmonic one-phonon ``1/omega``
+    intensity prefactor.  The default ``0`` reports the pure polarization,
+    probe-weight, mass, and interference visibility.
+    """
+
+    qpoints = np.atleast_2d(np.asarray(qpoints_reduced, dtype=float))
+    g_vectors = np.atleast_2d(np.asarray(g_vectors_reduced, dtype=float))
+    basis_pos = np.asarray(basis_positions_reduced, dtype=float)
+    masses = np.asarray(masses, dtype=float)
+    eig = np.asarray(eigenvectors, dtype=complex)
+
+    if qpoints.shape[1] != 3 or g_vectors.shape[1] != 3:
+        raise ValueError("qpoints_reduced and g_vectors_reduced must have shape (n, 3)")
+    if basis_pos.ndim != 2 or basis_pos.shape[1] != 3:
+        raise ValueError("basis_positions_reduced must have shape (num_basis, 3)")
+    if eig.shape[0] != qpoints.shape[0]:
+        raise ValueError("eigenvectors first axis must match qpoints")
+    if eig.shape[2:] != (basis_pos.shape[0], 3):
+        raise ValueError("eigenvectors must have shape (num_q, num_modes, num_basis, 3)")
+    if masses.shape[0] != basis_pos.shape[0]:
+        raise ValueError("masses must contain one value per basis atom")
+
+    reciprocal = reciprocal_lattice(primitive_cell)
+    pairwise = bool(pairwise_g_vectors)
+    if pairwise and g_vectors.shape != qpoints.shape:
+        raise ValueError("pairwise g_vectors must have the same shape as qpoints")
+    n_q = qpoints.shape[0]
+    n_g = 1 if pairwise else g_vectors.shape[0]
+    n_modes = eig.shape[1]
+    n_basis = basis_pos.shape[0]
+    Q_red = np.zeros((n_q, n_g, 3), dtype=float)
+    for i_q, q_red in enumerate(qpoints):
+        active_g_vectors = g_vectors[i_q:i_q + 1] if pairwise else g_vectors
+        for i_g, g_red in enumerate(active_g_vectors):
+            Q_red[i_q, i_g] = q_red + g_red
+    Q_cart = Q_red @ reciprocal
+
+    weights, weight_model = _resolve_probe_weights(
+        experiment,
+        atom_types,
+        Q_cart,
+        scattering_weights,
+        n_q,
+        n_g,
+        n_basis,
+        xray_form_factor_table=xray_form_factor_table,
+        xray_missing=xray_missing,
+    )
+    freq_scale = _frequency_scale(mode_frequencies, frequency_power, n_q, n_modes)
+
+    amplitude = np.zeros((n_q, n_g, n_modes), dtype=complex)
+    visibility = np.zeros((n_q, n_g, n_modes), dtype=float)
+    atom_amplitude = np.zeros((n_q, n_g, n_modes, n_basis), dtype=complex)
+    direction_amplitude = np.zeros((n_q, n_g, n_modes, 3), dtype=complex)
+
+    for i_q in range(n_q):
+        for i_g in range(n_g):
+            phase = np.exp(2j * np.pi * (basis_pos @ Q_red[i_q, i_g]))
+            prefactor = weights[i_q, i_g] * phase / np.sqrt(masses)
+            component = eig[i_q] * Q_cart[i_q, i_g].reshape(1, 1, 3)
+            contribution = component * prefactor.reshape(1, n_basis, 1)
+            contribution *= freq_scale[i_q].reshape(n_modes, 1, 1)
+            atom_amp = np.sum(contribution, axis=2)
+            direction_amp = np.sum(contribution, axis=1)
+            total_amp = np.sum(atom_amp, axis=1)
+            atom_amplitude[i_q, i_g] = atom_amp
+            direction_amplitude[i_q, i_g] = direction_amp
+            amplitude[i_q, i_g] = total_amp
+            visibility[i_q, i_g] = np.abs(total_amp) ** 2
+
+    atom_visibility = np.abs(atom_amplitude) ** 2
+    direction_visibility = np.abs(direction_amplitude) ** 2
+    atom_interference = visibility - np.sum(atom_visibility, axis=3)
+
+    return OnePhononVisibility(
+        qpoints_reduced=qpoints,
+        g_vectors_reduced=g_vectors,
+        Q_reduced=Q_red,
+        Q_cartesian=Q_cart,
+        amplitude=amplitude,
+        visibility=visibility,
+        atom_amplitude=atom_amplitude,
+        atom_visibility=atom_visibility,
+        direction_amplitude=direction_amplitude,
+        direction_visibility=direction_visibility,
+        atom_interference=atom_interference,
+        scattering_weights=weights,
+        metadata={
+            "model": "coherent one-phonon neutron/xray visibility",
+            "experiment": str(experiment).lower(),
+            "weight_model": weight_model,
+            "extended_zone": "Q = q + G",
+            "frequency_power": frequency_power,
+            "pairwise_g_vectors": pairwise,
+            "decomposition": "complex amplitudes; diagnostic intensities are not additive under interference",
+        },
+    )
+
+
+def compute_one_phonon_visibility_for_q_path(
+    qpoints_reduced,
+    g_vectors_reduced,
+    primitive_cell,
+    basis_positions_reduced,
+    masses,
+    eigenvectors,
+    atom_types=None,
+    experiment="neutron",
+    scattering_weights=None,
+    mode_frequencies=None,
+    frequency_power=0,
+    xray_form_factor_table=None,
+    xray_missing="atomic_number",
+):
+    """Compute coherent INS/IXS one-phonon visibility for a pairwise Q path."""
+
+    return compute_one_phonon_visibility(
+        qpoints_reduced,
+        g_vectors_reduced,
+        primitive_cell,
+        basis_positions_reduced,
+        masses,
+        eigenvectors,
+        atom_types=atom_types,
+        experiment=experiment,
+        scattering_weights=scattering_weights,
+        mode_frequencies=mode_frequencies,
+        frequency_power=frequency_power,
+        xray_form_factor_table=xray_form_factor_table,
+        xray_missing=xray_missing,
+        pairwise_g_vectors=True,
+    )
+
+
+def build_one_phonon_map(
+    visibility,
+    mode_frequencies,
+    energy_axis,
+    broadening,
+    broadening_kind="lorentzian",
+):
+    """Convert one-phonon visibility into a broadened harmonic map."""
+
+    vis = np.asarray(visibility.visibility, dtype=float)
+    mode_freq = np.asarray(mode_frequencies, dtype=float)
+    energy = np.asarray(energy_axis, dtype=float)
+    if mode_freq.shape != (vis.shape[0], vis.shape[2]):
+        raise ValueError("mode_frequencies must have shape (num_q, num_modes)")
+
+    intensity = np.zeros((vis.shape[0], vis.shape[1], energy.size), dtype=float)
+    for i_q in range(vis.shape[0]):
+        for i_g in range(vis.shape[1]):
+            for mode in range(vis.shape[2]):
+                center = mode_freq[i_q, mode]
+                if broadening_kind == "lorentzian":
+                    profile = lorentzian(energy, center, broadening)
+                elif broadening_kind == "gaussian":
+                    profile = gaussian(energy, center, broadening)
+                else:
+                    raise ValueError("broadening_kind must be 'lorentzian' or 'gaussian'")
+                intensity[i_q, i_g] += vis[i_q, i_g, mode] * profile
+
+    return OnePhononMap(
+        Q_reduced=visibility.Q_reduced,
+        Q_cartesian=visibility.Q_cartesian,
+        energy_axis=energy,
+        intensity=intensity,
+        visibility=vis,
+        metadata={
+            "source": "harmonic mode frequencies",
+            "broadening": float(broadening),
+            "broadening_kind": broadening_kind,
+            **visibility.metadata,
+        },
+    )
+
+
+def build_one_phonon_map_from_mode_spectra(visibility, mode_spectra, energy_axis):
+    """Weight branch-resolved spectra into coherent INS/IXS intensity maps.
+
+    ``mode_spectra`` must have shape ``(num_energy, num_q, num_modes)`` and can
+    be taken directly from :attr:`pySED.eigen_sed.EigenSEDResult.sed`.
+    """
+
+    vis = np.asarray(visibility.visibility, dtype=float)
+    spectra = np.asarray(mode_spectra, dtype=float)
+    energy = np.asarray(energy_axis, dtype=float)
+
+    if spectra.ndim != 3:
+        raise ValueError("mode_spectra must have shape (num_energy, num_q, num_modes)")
+    if spectra.shape[0] != energy.size:
+        raise ValueError("energy_axis length must match mode_spectra first dimension")
+    if spectra.shape[1:] != (vis.shape[0], vis.shape[2]):
+        raise ValueError("mode_spectra must have shape (num_energy, num_q, num_modes)")
+
+    intensity = np.einsum("qgm,eqm->qge", vis, spectra)
+    return OnePhononMap(
+        Q_reduced=visibility.Q_reduced,
+        Q_cartesian=visibility.Q_cartesian,
+        energy_axis=energy,
+        intensity=intensity,
+        visibility=vis,
+        metadata={
+            "source": "branch-resolved mode spectra",
+            **visibility.metadata,
+        },
+    )
+
+
+def build_one_phonon_decomposition_map_from_mode_spectra(visibility, mode_spectra, energy_axis):
+    """Build energy-resolved atom/direction/interference INS/IXS maps."""
+
+    vis = np.asarray(visibility.visibility, dtype=float)
+    atom_vis = np.asarray(visibility.atom_visibility, dtype=float)
+    direction_vis = np.asarray(visibility.direction_visibility, dtype=float)
+    atom_interference = np.asarray(visibility.atom_interference, dtype=float)
+    spectra = np.asarray(mode_spectra, dtype=float)
+    energy = np.asarray(energy_axis, dtype=float)
+
+    if spectra.ndim != 3:
+        raise ValueError("mode_spectra must have shape (num_energy, num_q, num_modes)")
+    if spectra.shape[0] != energy.size:
+        raise ValueError("energy_axis length must match mode_spectra first dimension")
+    if spectra.shape[1:] != (vis.shape[0], vis.shape[2]):
+        raise ValueError("mode_spectra must have shape (num_energy, num_q, num_modes)")
+
+    intensity = np.einsum("qgm,eqm->qge", vis, spectra)
+    atom_intensity = np.einsum("qgmb,eqm->qgbe", atom_vis, spectra)
+    direction_intensity = np.einsum("qgmd,eqm->qgde", direction_vis, spectra)
+    atom_interference_intensity = np.einsum("qgm,eqm->qge", atom_interference, spectra)
+
+    return OnePhononDecompositionMap(
+        Q_reduced=visibility.Q_reduced,
+        Q_cartesian=visibility.Q_cartesian,
+        energy_axis=energy,
+        intensity=intensity,
+        atom_intensity=atom_intensity,
+        direction_intensity=direction_intensity,
+        atom_interference_intensity=atom_interference_intensity,
+        visibility=vis,
+        atom_visibility=atom_vis,
+        direction_visibility=direction_vis,
+        atom_interference=atom_interference,
+        metadata={
+            "source": "branch-resolved mode spectra",
+            "decomposition": "diagnostic atom/direction maps; atom terms are not additive without interference",
+            **visibility.metadata,
+        },
+    )

--- a/pySED/probe_weights.py
+++ b/pySED/probe_weights.py
@@ -1,0 +1,275 @@
+"""Probe-specific scattering weights.
+
+This module keeps scattering constants separate from the DSF estimators.  The
+X-ray path uses the Cromer-Mann analytic approximation for the neutral-atom
+form factor,
+
+    f0(s) = sum_i a_i exp(-b_i s**2) + c,  s = abs(Q) / (4*pi).
+
+``Q`` is expected in inverse Angstrom.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+ATOMIC_NUMBERS = {
+    "H": 1,
+    "B": 5,
+    "C": 6,
+    "N": 7,
+    "O": 8,
+    "Na": 11,
+    "Al": 13,
+    "Si": 14,
+    "P": 15,
+    "S": 16,
+    "Mo": 42,
+    "Cu": 29,
+    "Se": 34,
+    "Zr": 40,
+    "W": 74,
+}
+
+
+@dataclass(frozen=True)
+class CromerMannCoefficients:
+    """Four-Gaussian Cromer-Mann coefficients for an atomic form factor."""
+
+    a: tuple
+    b: tuple
+    c: float
+    source: str = "Cromer and Mann neutral-atom analytic form"
+
+    def __post_init__(self):
+        if len(self.a) != 4 or len(self.b) != 4:
+            raise ValueError("Cromer-Mann coefficients require four a and four b values")
+
+
+def _cm(a1, b1, a2, b2, a3, b3, a4, b4, c):
+    return CromerMannCoefficients(
+        a=(float(a1), float(a2), float(a3), float(a4)),
+        b=(float(b1), float(b2), float(b3), float(b4)),
+        c=float(c),
+    )
+
+
+# A compact built-in table for elements already used in pySED's neutron/X-ray
+# defaults.  Users can pass their own table for ions, anomalous terms, or
+# elements not included here.
+CROMER_MANN_COEFFICIENTS = {
+    "H": _cm(0.493002, 10.5109, 0.322912, 26.1257, 0.140191, 3.14236, 0.040810, 57.7997, 0.003038),
+    "B": _cm(2.0545, 23.2185, 1.3326, 1.0210, 1.0979, 60.3498, 0.7068, 0.1403, -0.1932),
+    "C": _cm(2.3100, 20.8439, 1.0200, 10.2075, 1.5886, 0.5687, 0.8650, 51.6512, 0.2156),
+    "N": _cm(12.2126, 0.0057, 3.1322, 9.8933, 2.0125, 28.9975, 1.1663, 0.5826, -11.529),
+    "O": _cm(3.0485, 13.2771, 2.2868, 5.7011, 1.5463, 0.3239, 0.8670, 32.9089, 0.2508),
+    "Na": _cm(4.7626, 3.2850, 3.1736, 8.8422, 1.2674, 0.3136, 1.1128, 129.424, 0.6760),
+    "Al": _cm(6.4202, 3.0387, 1.9002, 0.7426, 1.5936, 31.5472, 1.9646, 85.0886, 1.1151),
+    "Si": _cm(6.2915, 2.4386, 3.0353, 32.3337, 1.9891, 0.6785, 1.5410, 81.6937, 1.1407),
+    "P": _cm(6.4345, 1.9067, 4.1791, 27.1570, 1.7800, 0.5260, 1.4908, 68.1645, 1.1149),
+    "S": _cm(6.9053, 1.4679, 5.2034, 22.2151, 1.4379, 0.2536, 1.5863, 56.1720, 0.8669),
+    "Mo": _cm(3.7025, 0.2772, 17.2356, 1.0958, 12.8876, 11.0040, 3.7429, 61.6584, 4.3875),
+    "Cu": _cm(13.3380, 3.5828, 7.1676, 0.2470, 5.6158, 11.3966, 1.6735, 64.8126, 1.1910),
+    "Se": _cm(17.0006, 2.4098, 5.8196, 0.2726, 3.9731, 15.2372, 4.3543, 43.8163, 2.8409),
+    "Zr": _cm(17.8765, 1.27618, 10.9480, 11.9160, 5.41732, 0.117622, 3.65721, 87.6627, 2.06929),
+    "W": _cm(29.0818, 1.72029, 15.4300, 9.22590, 14.4327, 0.321703, 5.11982, 57.0560, 9.88750),
+}
+
+
+def coerce_cromer_mann_coefficients(value):
+    """Return ``value`` as :class:`CromerMannCoefficients`.
+
+    ``value`` can be a ``CromerMannCoefficients`` instance, a mapping with
+    ``a``, ``b``, and ``c`` keys, or a flat nine-value iterable ordered as
+    ``a1, b1, a2, b2, a3, b3, a4, b4, c``.
+    """
+
+    if isinstance(value, CromerMannCoefficients):
+        return value
+    if isinstance(value, dict):
+        return CromerMannCoefficients(
+            a=tuple(value["a"]),
+            b=tuple(value["b"]),
+            c=float(value["c"]),
+            source=value.get("source", "user supplied"),
+        )
+
+    values = tuple(float(item) for item in value)
+    if len(values) != 9:
+        raise ValueError("flat Cromer-Mann coefficients must contain nine values")
+    return _cm(*values)
+
+
+def cromer_mann_form_factor(q_magnitude, coefficients):
+    """Evaluate the Cromer-Mann form factor for ``|Q|`` in inverse Angstrom."""
+
+    coeffs = coerce_cromer_mann_coefficients(coefficients)
+    q = np.asarray(q_magnitude, dtype=float)
+    s_squared = (q / (4.0 * np.pi)) ** 2
+    a = np.asarray(coeffs.a, dtype=float)
+    b = np.asarray(coeffs.b, dtype=float)
+    values = np.sum(a.reshape((-1,) + (1,) * s_squared.ndim) * np.exp(-b.reshape((-1,) + (1,) * s_squared.ndim) * s_squared), axis=0)
+    return values + coeffs.c
+
+
+def mott_bethe_electron_form_factor(q_magnitude, atomic_number, coefficients, small_q=1e-8):
+    """Return a relative electron scattering factor from Mott-Bethe.
+
+    The returned value is proportional to ``(Z - f_x(Q)) / |Q|**2`` with
+    ``Q`` in inverse Angstrom.  The dimensional constant is omitted because
+    pySED's kinematic EELS visibility uses relative intensities by default.
+    The ``Q -> 0`` limit is evaluated analytically from the Cromer-Mann
+    derivative.
+    """
+
+    coeffs = coerce_cromer_mann_coefficients(coefficients)
+    scalar_input = np.ndim(q_magnitude) == 0
+    q = np.atleast_1d(np.asarray(q_magnitude, dtype=float))
+    q_squared = q ** 2
+    xray = cromer_mann_form_factor(q, coeffs)
+    numerator = float(atomic_number) - xray
+    factor = np.empty_like(q, dtype=float)
+    small = np.abs(q) < float(small_q)
+
+    with np.errstate(divide="ignore", invalid="ignore"):
+        factor[~small] = numerator[~small] / q_squared[~small]
+
+    a = np.asarray(coeffs.a, dtype=float)
+    b = np.asarray(coeffs.b, dtype=float)
+    limit = float(np.sum(a * b) / (16.0 * np.pi ** 2))
+    factor[small] = limit
+    if scalar_input:
+        return float(factor[0])
+    return factor
+
+
+def atomic_number_weights(atom_types, qpoints_cartesian=None, missing="raise"):
+    """Return atomic-number X-ray weights.
+
+    This is a fallback for elements without form-factor coefficients.  It is
+    useful for exploratory calculations but should not be treated as an
+    experiment-quality X-ray model.
+    """
+
+    if atom_types is None:
+        return None
+    values = []
+    for atom in atom_types:
+        key = str(atom)
+        if key not in ATOMIC_NUMBERS:
+            if missing == "zero":
+                values.append(0.0)
+                continue
+            raise KeyError("missing atomic number for atom type %s" % key)
+        values.append(float(ATOMIC_NUMBERS[key]))
+
+    weights = np.asarray(values, dtype=float)
+    if qpoints_cartesian is None:
+        return weights
+    qpoints = np.atleast_2d(np.asarray(qpoints_cartesian, dtype=float))
+    return np.tile(weights.reshape(1, -1), (qpoints.shape[0], 1))
+
+
+def xray_form_factor_weights(
+    atom_types,
+    qpoints_cartesian=None,
+    coefficients_table=None,
+    missing="atomic_number",
+):
+    """Return q-dependent X-ray form-factor weights.
+
+    Parameters
+    ----------
+    atom_types
+        Element symbols for each atom.
+    qpoints_cartesian
+        ``Q`` points in inverse Angstrom.  If omitted, ``Q=0`` weights are
+        returned as a one-dimensional atom array.
+    coefficients_table
+        Optional mapping from atom symbol to Cromer-Mann coefficients.  Entries
+        override the built-in neutral-atom table.
+    missing
+        ``"atomic_number"`` falls back to :func:`atomic_number_weights`,
+        ``"zero"`` inserts zero weights, and ``"raise"`` raises ``KeyError``.
+    """
+
+    if atom_types is None:
+        return None
+    if missing not in ("atomic_number", "zero", "raise"):
+        raise ValueError("missing must be 'atomic_number', 'zero', or 'raise'")
+
+    table = dict(CROMER_MANN_COEFFICIENTS)
+    if coefficients_table:
+        table.update(coefficients_table)
+
+    qpoints = None
+    if qpoints_cartesian is not None:
+        qpoints = np.atleast_2d(np.asarray(qpoints_cartesian, dtype=float))
+        if qpoints.shape[1] != 3:
+            raise ValueError("qpoints_cartesian must have shape (num_qpoints, 3)")
+        q_magnitude = np.linalg.norm(qpoints, axis=1)
+    else:
+        q_magnitude = np.asarray([0.0], dtype=float)
+
+    output = np.zeros((q_magnitude.shape[0], len(atom_types)), dtype=float)
+    for atom_index, atom in enumerate(atom_types):
+        key = str(atom)
+        if key in table:
+            output[:, atom_index] = cromer_mann_form_factor(q_magnitude, table[key])
+        elif missing == "atomic_number":
+            if key not in ATOMIC_NUMBERS:
+                raise KeyError("missing atomic number for atom type %s" % key)
+            output[:, atom_index] = float(ATOMIC_NUMBERS[key])
+        elif missing == "zero":
+            output[:, atom_index] = 0.0
+        else:
+            raise KeyError("missing Cromer-Mann coefficients for atom type %s" % key)
+
+    if qpoints_cartesian is None:
+        return output[0]
+    return output
+
+
+def electron_form_factor_weights(
+    atom_types,
+    qpoints_cartesian,
+    coefficients_table=None,
+    missing="raise",
+):
+    """Return relative electron form-factor weights using Mott-Bethe.
+
+    This is a neutral-atom, first-Born approximation suitable for kinematic
+    EELS visibility estimates.  For quantitative electron diffraction or
+    multislice calculations, users should pass a dedicated electron-scattering
+    table through the higher-level EELS API.
+    """
+
+    if atom_types is None:
+        return None
+    if missing not in ("zero", "raise"):
+        raise ValueError("missing must be 'zero' or 'raise'")
+
+    qpoints = np.atleast_2d(np.asarray(qpoints_cartesian, dtype=float))
+    if qpoints.shape[1] != 3:
+        raise ValueError("qpoints_cartesian must have shape (num_qpoints, 3)")
+    q_magnitude = np.linalg.norm(qpoints, axis=1)
+
+    table = dict(CROMER_MANN_COEFFICIENTS)
+    if coefficients_table:
+        table.update(coefficients_table)
+
+    output = np.zeros((q_magnitude.shape[0], len(atom_types)), dtype=float)
+    for atom_index, atom in enumerate(atom_types):
+        key = str(atom)
+        if key in table and key in ATOMIC_NUMBERS:
+            output[:, atom_index] = mott_bethe_electron_form_factor(
+                q_magnitude,
+                ATOMIC_NUMBERS[key],
+                table[key],
+            )
+        elif missing == "zero":
+            output[:, atom_index] = 0.0
+        else:
+            raise KeyError("missing electron form-factor data for atom type %s" % key)
+    return output

--- a/pySED/q_advisor.py
+++ b/pySED/q_advisor.py
@@ -1,0 +1,933 @@
+"""Q-point utilities for finite periodic MD trajectories.
+
+The routines in this module make the supercell commensurability condition
+explicit.  For a primitive cell ``p`` and a simulation supercell ``S`` with
+``S = P @ p``, a reduced q point is compatible with the trajectory if
+
+    q_red @ P.T is an integer vector.
+
+This is the same condition used by the existing Brillouin-zone path builder,
+but exposed as reusable API for SED, DSF, EELS, and experiment comparison.
+"""
+
+from dataclasses import dataclass
+from fractions import Fraction
+import csv
+import itertools
+import math
+
+import numpy as np
+
+
+def _lcm(a, b):
+    return abs(a * b) // math.gcd(a, b)
+
+
+@dataclass(frozen=True)
+class QPointAdvice:
+    """Result of mapping one requested q point to the commensurate grid."""
+
+    requested_reduced: np.ndarray
+    nearest_reduced: np.ndarray
+    requested_cartesian: np.ndarray
+    nearest_cartesian: np.ndarray
+    is_commensurate: bool
+    error_reduced: float
+    error_cartesian: float
+    integer_supercell_index: np.ndarray
+
+
+@dataclass(frozen=True)
+class QPointMesh:
+    """Selected-Q mesh in reduced reciprocal coordinates."""
+
+    qpoints_reduced: np.ndarray
+    axes: tuple
+    mesh_shape: tuple
+
+    def reshape_values(self, values):
+        """Reshape per-Q values back onto the selected-Q mesh."""
+
+        arr = np.asarray(values)
+        if arr.shape[0] != self.qpoints_reduced.shape[0]:
+            raise ValueError("values first dimension must match number of q points")
+        return arr.reshape(tuple(self.mesh_shape) + arr.shape[1:])
+
+
+@dataclass(frozen=True)
+class QPathSegments:
+    """Selected-Q path assembled from one or more linear segments."""
+
+    qpoints_reduced: np.ndarray
+    path_axis: np.ndarray
+    segment_start_indices: np.ndarray
+    segment_end_indices: np.ndarray
+
+
+@dataclass(frozen=True)
+class SelectedQEfficiencyReport:
+    """Cost estimate for selected-Q evaluation relative to a full q grid."""
+
+    num_selected_qpoints: int
+    num_full_qpoints: int
+    selected_fraction: float
+    qpoint_reduction_factor: float
+    num_frames: int = None
+    num_atoms: int = None
+    selected_phase_evaluations: float = None
+    full_phase_evaluations: float = None
+    selected_fft_work_units: float = None
+    full_fft_work_units: float = None
+
+    def summary(self):
+        """Return a JSON-serializable cost summary."""
+
+        return {
+            "num_selected_qpoints": self.num_selected_qpoints,
+            "num_full_qpoints": self.num_full_qpoints,
+            "selected_fraction": self.selected_fraction,
+            "qpoint_reduction_factor": self.qpoint_reduction_factor,
+            "num_frames": self.num_frames,
+            "num_atoms": self.num_atoms,
+            "selected_phase_evaluations": self.selected_phase_evaluations,
+            "full_phase_evaluations": self.full_phase_evaluations,
+            "selected_fft_work_units": self.selected_fft_work_units,
+            "full_fft_work_units": self.full_fft_work_units,
+        }
+
+    def to_table(self, precision=6):
+        """Return a compact plain-text table for logs or methods notes."""
+
+        fmt = "%%.%df" % int(precision)
+
+        def val(item):
+            if item is None:
+                return "n/a"
+            if isinstance(item, (int, np.integer)):
+                return str(int(item))
+            return fmt % float(item)
+
+        rows = [
+            ("selected q points", val(self.num_selected_qpoints)),
+            ("full commensurate grid points", val(self.num_full_qpoints)),
+            ("selected fraction", val(self.selected_fraction)),
+            ("q-point reduction factor", val(self.qpoint_reduction_factor)),
+            ("selected phase evaluations", val(self.selected_phase_evaluations)),
+            ("full-grid phase evaluations", val(self.full_phase_evaluations)),
+            ("selected FFT work units", val(self.selected_fft_work_units)),
+            ("full-grid FFT work units", val(self.full_fft_work_units)),
+        ]
+        width = max(len(label) for label, _ in rows)
+        return "\n".join("%s  %s" % (label.ljust(width), value) for label, value in rows)
+
+
+@dataclass(frozen=True)
+class QAdvisorReport:
+    """Vectorized report for an experimental q or Q path.
+
+    The report keeps the requested points, the nearest commensurate points, the
+    finite-supercell integer indices, and a diagonal-supercell recommendation in
+    one object so scripts can print, export, or archive the q-selection decision
+    before running SED, DSF, or EELS calculations.
+    """
+
+    coordinate_system: str
+    preserve_image: bool
+    requested_reduced: np.ndarray
+    nearest_reduced: np.ndarray
+    requested_cartesian: np.ndarray
+    nearest_cartesian: np.ndarray
+    is_commensurate: np.ndarray
+    error_reduced: np.ndarray
+    error_cartesian: np.ndarray
+    integer_supercell_indices: np.ndarray
+    suggested_diagonal_supercell: np.ndarray
+
+    @property
+    def num_points(self):
+        return int(self.requested_reduced.shape[0])
+
+    @property
+    def num_commensurate(self):
+        return int(np.count_nonzero(self.is_commensurate))
+
+    @property
+    def all_commensurate(self):
+        return bool(np.all(self.is_commensurate))
+
+    @property
+    def max_error_reduced(self):
+        return float(np.max(self.error_reduced)) if self.error_reduced.size else 0.0
+
+    @property
+    def max_error_cartesian(self):
+        return float(np.max(self.error_cartesian)) if self.error_cartesian.size else 0.0
+
+    def summary(self):
+        """Return scalar report metadata useful for logs or JSON exports."""
+
+        return {
+            "coordinate_system": self.coordinate_system,
+            "preserve_image": self.preserve_image,
+            "num_points": self.num_points,
+            "num_commensurate": self.num_commensurate,
+            "all_commensurate": self.all_commensurate,
+            "max_error_reduced": self.max_error_reduced,
+            "max_error_cartesian": self.max_error_cartesian,
+            "suggested_diagonal_supercell": self.suggested_diagonal_supercell.tolist(),
+        }
+
+    def to_records(self, flat=False):
+        """Return one serializable record per requested point."""
+
+        records = []
+        for index in range(self.num_points):
+            record = {
+                "index": int(index),
+                "is_commensurate": bool(self.is_commensurate[index]),
+                "requested_reduced": self.requested_reduced[index].tolist(),
+                "nearest_reduced": self.nearest_reduced[index].tolist(),
+                "requested_cartesian": self.requested_cartesian[index].tolist(),
+                "nearest_cartesian": self.nearest_cartesian[index].tolist(),
+                "error_reduced": float(self.error_reduced[index]),
+                "error_cartesian": float(self.error_cartesian[index]),
+                "integer_supercell_index": self.integer_supercell_indices[index].astype(int).tolist(),
+            }
+            if flat:
+                record = _flatten_report_record(record)
+            records.append(record)
+        return records
+
+    def to_dict(self):
+        """Return a JSON-serializable report dictionary."""
+
+        return {"summary": self.summary(), "points": self.to_records()}
+
+    def write_csv(self, path):
+        """Write the q-advisor point table to ``path`` as CSV."""
+
+        records = self.to_records(flat=True)
+        fieldnames = list(records[0].keys()) if records else [
+            "index",
+            "is_commensurate",
+            "error_reduced",
+            "error_cartesian",
+        ]
+        with open(path, "w", newline="", encoding="utf-8") as handle:
+            writer = csv.DictWriter(handle, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(records)
+
+    def to_table(self, precision=6):
+        """Return a compact plain-text table for terminal logs."""
+
+        fmt = "%%.%df" % int(precision)
+
+        def vec(values):
+            return "[" + ", ".join(fmt % float(x) for x in values) + "]"
+
+        rows = [
+            [
+                str(index),
+                str(bool(self.is_commensurate[index])),
+                vec(self.requested_reduced[index]),
+                vec(self.nearest_reduced[index]),
+                fmt % float(self.error_reduced[index]),
+                fmt % float(self.error_cartesian[index]),
+                "[" + ", ".join(str(int(x)) for x in self.integer_supercell_indices[index]) + "]",
+            ]
+            for index in range(self.num_points)
+        ]
+        headers = ["idx", "ok", "requested_red", "nearest_red", "err_red", "err_cart", "supercell_n"]
+        widths = [
+            max(len(headers[col]), *(len(row[col]) for row in rows)) if rows else len(headers[col])
+            for col in range(len(headers))
+        ]
+        lines = [
+            "  ".join(headers[col].ljust(widths[col]) for col in range(len(headers))),
+            "  ".join("-" * width for width in widths),
+        ]
+        lines.extend(
+            "  ".join(row[col].ljust(widths[col]) for col in range(len(headers)))
+            for row in rows
+        )
+        lines.append("suggested_diagonal_supercell = %s" % self.suggested_diagonal_supercell.tolist())
+        return "\n".join(lines)
+
+
+@dataclass(frozen=True)
+class ExtendedZoneQPathPlan:
+    """Pairwise ``Q = q + G`` plan for extended-zone scattering paths."""
+
+    report: QAdvisorReport
+    Q_reduced: np.ndarray
+    Q_cartesian: np.ndarray
+    qpoints_reduced: np.ndarray
+    qpoints_cartesian: np.ndarray
+    g_vectors_reduced: np.ndarray
+    g_vectors_cartesian: np.ndarray
+
+    @property
+    def num_points(self):
+        return int(self.Q_reduced.shape[0])
+
+    def to_records(self, flat=False):
+        records = []
+        report_records = self.report.to_records(flat=False)
+        for index, record in enumerate(report_records):
+            enriched = dict(record)
+            enriched.update(
+                {
+                    "Q_reduced": self.Q_reduced[index].tolist(),
+                    "Q_cartesian": self.Q_cartesian[index].tolist(),
+                    "folded_q_reduced": self.qpoints_reduced[index].tolist(),
+                    "folded_q_cartesian": self.qpoints_cartesian[index].tolist(),
+                    "G_reduced": self.g_vectors_reduced[index].astype(int).tolist(),
+                    "G_cartesian": self.g_vectors_cartesian[index].tolist(),
+                }
+            )
+            if flat:
+                enriched = _flatten_extended_zone_record(enriched)
+            records.append(enriched)
+        return records
+
+    def to_dict(self):
+        return {"summary": self.report.summary(), "points": self.to_records()}
+
+    def write_phonopy_qpoints(self, path):
+        """Write folded commensurate q points for phonopy eigenvectors."""
+
+        np.savetxt(path, self.qpoints_reduced, fmt="%.10f")
+
+    def write_csv(self, path):
+        """Write the extended-zone path plan to ``path`` as CSV."""
+
+        records = self.to_records(flat=True)
+        fieldnames = list(records[0].keys()) if records else ["index"]
+        with open(path, "w", newline="", encoding="utf-8") as handle:
+            writer = csv.DictWriter(handle, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(records)
+
+
+def _flatten_report_record(record):
+    flat = {
+        "index": record["index"],
+        "is_commensurate": record["is_commensurate"],
+        "error_reduced": record["error_reduced"],
+        "error_cartesian": record["error_cartesian"],
+    }
+    for key in ("requested_reduced", "nearest_reduced", "requested_cartesian", "nearest_cartesian"):
+        for axis, value in enumerate(record[key]):
+            flat["%s_%d" % (key, axis + 1)] = value
+    for axis, value in enumerate(record["integer_supercell_index"]):
+        flat["integer_supercell_index_%d" % (axis + 1)] = value
+    return flat
+
+
+def _flatten_extended_zone_record(record):
+    flat = _flatten_report_record(record)
+    for key in ("Q_reduced", "Q_cartesian", "folded_q_reduced", "folded_q_cartesian", "G_cartesian"):
+        for axis, value in enumerate(record[key]):
+            flat["%s_%d" % (key, axis + 1)] = value
+    for axis, value in enumerate(record["G_reduced"]):
+        flat["G_reduced_%d" % (axis + 1)] = value
+    return flat
+
+
+def compute_repetition_matrix(primitive_cell, supercell_cell, atol=1e-4):
+    """Return integer ``P`` such that ``supercell_cell = P @ primitive_cell``."""
+
+    primitive = np.asarray(primitive_cell, dtype=float)
+    supercell = np.asarray(supercell_cell, dtype=float)
+    if primitive.shape != (3, 3) or supercell.shape != (3, 3):
+        raise ValueError("primitive_cell and supercell_cell must be 3x3 matrices")
+
+    p_float = np.linalg.solve(primitive.T, supercell.T).T
+    p_int = np.rint(p_float).astype(int)
+    if not np.allclose(p_float, p_int, atol=atol):
+        raise ValueError("supercell is not an integer multiple of primitive_cell")
+    return p_int
+
+
+def reciprocal_lattice(cell):
+    """Return reciprocal lattice vectors as rows, including the 2*pi factor."""
+
+    cell = np.asarray(cell, dtype=float)
+    if cell.shape != (3, 3):
+        raise ValueError("cell must be a 3x3 matrix")
+    return 2.0 * np.pi * np.linalg.inv(cell.T)
+
+
+def wrap_reduced(q_red, centered=False):
+    """Wrap reduced coordinates into [0, 1) or [-0.5, 0.5)."""
+
+    q = np.asarray(q_red, dtype=float)
+    wrapped = q - np.floor(q)
+    if centered:
+        wrapped = wrapped - np.round(wrapped)
+    return np.where(np.isclose(wrapped, 0.0, atol=1e-14), 0.0, wrapped)
+
+
+def reduced_delta(q1, q2):
+    """Shortest periodic difference between reduced reciprocal coordinates."""
+
+    dq = np.asarray(q1, dtype=float) - np.asarray(q2, dtype=float)
+    return dq - np.round(dq)
+
+
+def split_extended_zone_qpoints(qpoints_reduced):
+    """Split reduced extended-zone ``Q`` points into folded ``q`` and ``G``.
+
+    The folded q points use the centered first Brillouin-zone image.  The
+    returned G vectors are integer reduced reciprocal-lattice vectors satisfying
+    ``Q = q + G`` within floating-point tolerance.
+    """
+
+    Q = np.atleast_2d(np.asarray(qpoints_reduced, dtype=float))
+    if Q.shape[1] != 3:
+        raise ValueError("qpoints_reduced must have shape (num_qpoints, 3)")
+    q_folded = wrap_reduced(Q, centered=True)
+    g_vectors = Q - q_folded
+    g_integer = np.rint(g_vectors).astype(int)
+    if not np.allclose(g_vectors, g_integer, atol=1e-8):
+        raise ValueError("extended-zone split did not produce integer G vectors")
+    return q_folded, g_integer
+
+
+def qpoints_from_path_axis(q_axis, start_qpoint, end_qpoint):
+    """Interpolate vector Q points along a calibrated scalar q-path axis.
+
+    Experimental maps often store only a scalar horizontal axis, for example a
+    path distance or detector coordinate after calibration.  This helper maps
+    each scalar axis value linearly between two vector endpoints.  The returned
+    vectors use the same coordinate system as ``start_qpoint`` and
+    ``end_qpoint``.
+    """
+
+    axis = np.asarray(q_axis, dtype=float)
+    start = np.asarray(start_qpoint, dtype=float)
+    end = np.asarray(end_qpoint, dtype=float)
+    if axis.ndim != 1:
+        raise ValueError("q_axis must be one-dimensional")
+    if axis.size < 1:
+        raise ValueError("q_axis must contain at least one point")
+    if start.shape != (3,) or end.shape != (3,):
+        raise ValueError("start_qpoint and end_qpoint must have shape (3,)")
+    if axis.size == 1:
+        return start.reshape(1, 3)
+
+    diffs = np.diff(axis)
+    if np.any(diffs == 0.0) or not (np.all(diffs > 0.0) or np.all(diffs < 0.0)):
+        raise ValueError("q_axis must be strictly monotonic")
+    span = axis[-1] - axis[0]
+    fractions = (axis - axis[0]) / span
+    return start.reshape(1, 3) + fractions.reshape(-1, 1) * (end - start).reshape(1, 3)
+
+
+def _mesh_axis(spec):
+    arr = np.asarray(spec, dtype=float)
+    if arr.ndim == 0:
+        return np.asarray([float(arr)], dtype=float)
+    arr = arr.ravel()
+    if arr.size == 1:
+        return np.asarray([float(arr[0])], dtype=float)
+    if arr.size != 3:
+        raise ValueError("mesh axis spec must be a scalar or [start, stop, num]")
+    num = int(round(arr[2]))
+    if num < 1 or not np.isclose(arr[2], num):
+        raise ValueError("mesh axis num must be a positive integer")
+    if num == 1:
+        return np.asarray([float(arr[0])], dtype=float)
+    return np.linspace(float(arr[0]), float(arr[1]), num)
+
+
+def qpoints_from_mesh(h_axis, k_axis, l_axis):
+    """Generate a pynamic-style selected-Q mesh in reduced coordinates.
+
+    Each axis may be a scalar or ``[start, stop, num]``.  The function does not
+    enforce commensurability; pass the returned ``qpoints_reduced`` to
+    :class:`QAdvisor` before using the points with finite periodic
+    trajectories.
+    """
+
+    h = _mesh_axis(h_axis)
+    k = _mesh_axis(k_axis)
+    l = _mesh_axis(l_axis)
+    H, K, L = np.meshgrid(h, k, l, indexing="ij")
+    qpoints = np.column_stack([H.ravel(), K.ravel(), L.ravel()])
+    return QPointMesh(
+        qpoints_reduced=qpoints,
+        axes=(h, k, l),
+        mesh_shape=(h.size, k.size, l.size),
+    )
+
+
+def qpoints_from_path_segments(starts, ends, steps, endpoint=False):
+    """Generate selected Q points along one or more reduced-coordinate paths.
+
+    This follows the selected-path convention used by pynamic-structure-factor:
+    each segment is sampled with ``steps`` points; by default the segment end
+    point is omitted to avoid duplicate vertices when consecutive segments
+    share endpoints.  Use ``endpoint=True`` when every segment should include
+    its final point.
+    """
+
+    starts = np.atleast_2d(np.asarray(starts, dtype=float))
+    ends = np.atleast_2d(np.asarray(ends, dtype=float))
+    steps = np.asarray(steps, dtype=int).ravel()
+    if starts.shape != ends.shape or starts.shape[1] != 3:
+        raise ValueError("starts and ends must both have shape (num_segments, 3)")
+    if steps.shape != (starts.shape[0],):
+        raise ValueError("steps length must match number of path segments")
+    if np.any(steps < 1):
+        raise ValueError("all path segment steps must be positive")
+
+    qpoints = []
+    path_axis = []
+    start_indices = []
+    end_indices = []
+    distance = 0.0
+    previous_end = None
+    for seg_index, (start, end, count) in enumerate(zip(starts, ends, steps)):
+        start_indices.append(len(qpoints))
+        sample_count = int(count)
+        fractions = np.linspace(0.0, 1.0, sample_count if endpoint else sample_count + 1)
+        if not endpoint:
+            fractions = fractions[:-1]
+        segment = start.reshape(1, 3) + fractions.reshape(-1, 1) * (end - start).reshape(1, 3)
+        if previous_end is not None:
+            distance += float(np.linalg.norm(start - previous_end))
+        segment_length = float(np.linalg.norm(end - start))
+        segment_axis = distance + fractions * segment_length
+        qpoints.extend(segment)
+        path_axis.extend(segment_axis)
+        if len(qpoints) == start_indices[-1]:
+            end_indices.append(start_indices[-1])
+        else:
+            end_indices.append(len(qpoints) - 1)
+        distance += segment_length
+        previous_end = end
+
+    return QPathSegments(
+        qpoints_reduced=np.asarray(qpoints, dtype=float),
+        path_axis=np.asarray(path_axis, dtype=float),
+        segment_start_indices=np.asarray(start_indices, dtype=int),
+        segment_end_indices=np.asarray(end_indices, dtype=int),
+    )
+
+
+def estimate_selected_q_efficiency(
+    num_selected_qpoints,
+    num_full_qpoints,
+    num_frames=None,
+    num_atoms=None,
+):
+    """Estimate selected-Q savings relative to evaluating a full q grid.
+
+    The estimate follows the direct DSF cost model
+    ``O(N_Q * N_t * N) + O(N_Q * N_t * log(N_t))``.  The phase-evaluation
+    counts are exact under this model when ``num_frames`` and ``num_atoms`` are
+    supplied; FFT work units are proportional estimates.
+    """
+
+    selected = int(num_selected_qpoints)
+    full = int(num_full_qpoints)
+    if selected < 1:
+        raise ValueError("num_selected_qpoints must be positive")
+    if full < 1:
+        raise ValueError("num_full_qpoints must be positive")
+
+    selected_fraction = float(selected / full)
+    reduction = float(full / selected)
+    frames = None if num_frames is None else int(num_frames)
+    atoms = None if num_atoms is None else int(num_atoms)
+    if frames is not None and frames < 1:
+        raise ValueError("num_frames must be positive")
+    if atoms is not None and atoms < 1:
+        raise ValueError("num_atoms must be positive")
+
+    selected_phase = None
+    full_phase = None
+    if frames is not None and atoms is not None:
+        selected_phase = float(selected * frames * atoms)
+        full_phase = float(full * frames * atoms)
+
+    selected_fft = None
+    full_fft = None
+    if frames is not None:
+        fft_units_per_q = float(frames * math.log2(max(frames, 2)))
+        selected_fft = float(selected * fft_units_per_q)
+        full_fft = float(full * fft_units_per_q)
+
+    return SelectedQEfficiencyReport(
+        num_selected_qpoints=selected,
+        num_full_qpoints=full,
+        selected_fraction=selected_fraction,
+        qpoint_reduction_factor=reduction,
+        num_frames=frames,
+        num_atoms=atoms,
+        selected_phase_evaluations=selected_phase,
+        full_phase_evaluations=full_phase,
+        selected_fft_work_units=selected_fft,
+        full_fft_work_units=full_fft,
+    )
+
+
+class QAdvisor:
+    """Construct, validate, and map q points for a finite MD supercell."""
+
+    def __init__(self, primitive_cell, supercell_cell, atol=1e-8):
+        self.primitive_cell = np.asarray(primitive_cell, dtype=float)
+        self.supercell_cell = np.asarray(supercell_cell, dtype=float)
+        self.atol = atol
+        self.P = compute_repetition_matrix(
+            self.primitive_cell, self.supercell_cell, atol=max(atol, 1e-4)
+        )
+        self.reciprocal_primitive = reciprocal_lattice(self.primitive_cell)
+        self.num_commensurate_qpoints = int(abs(round(np.linalg.det(self.P))))
+
+    def reduced_to_cartesian(self, qpoints_reduced):
+        q = np.asarray(qpoints_reduced, dtype=float)
+        return np.atleast_2d(q) @ self.reciprocal_primitive
+
+    def cartesian_to_reduced(self, qpoints_cartesian):
+        q = np.asarray(qpoints_cartesian, dtype=float)
+        return np.linalg.solve(self.reciprocal_primitive.T, np.atleast_2d(q).T).T
+
+    def supercell_indices(self, qpoints_reduced):
+        q = np.atleast_2d(np.asarray(qpoints_reduced, dtype=float))
+        return q @ self.P.T
+
+    def is_commensurate(self, qpoint_reduced, atol=None):
+        indices = self.supercell_indices(qpoint_reduced)[0]
+        return bool(np.allclose(indices, np.rint(indices), atol=atol or self.atol))
+
+    def validate_qpoints(self, qpoints_reduced, atol=None):
+        q = np.atleast_2d(np.asarray(qpoints_reduced, dtype=float))
+        indices = self.supercell_indices(q)
+        return np.allclose(indices, np.rint(indices), atol=atol or self.atol, rtol=0.0)
+
+    def estimate_selected_q_efficiency(
+        self,
+        qpoints_reduced=None,
+        num_selected_qpoints=None,
+        num_frames=None,
+        num_atoms=None,
+    ):
+        """Estimate selected-Q savings against this supercell's full q grid."""
+
+        if qpoints_reduced is None and num_selected_qpoints is None:
+            raise ValueError("supply qpoints_reduced or num_selected_qpoints")
+        if qpoints_reduced is not None:
+            selected = np.atleast_2d(np.asarray(qpoints_reduced, dtype=float)).shape[0]
+        else:
+            selected = int(num_selected_qpoints)
+        return estimate_selected_q_efficiency(
+            selected,
+            self.num_commensurate_qpoints,
+            num_frames=num_frames,
+            num_atoms=num_atoms,
+        )
+
+    def commensurate_grid(self, centered=False, max_bound=256):
+        """Return all distinct commensurate q points modulo primitive G vectors.
+
+        For diagonal supercells this is the usual ``i/Nx, j/Ny, k/Nz`` grid.  For
+        non-diagonal integer repetition matrices, a bounded integer enumeration is
+        used and stopped once ``abs(det(P))`` unique q points are found.
+        """
+
+        target = self.num_commensurate_qpoints
+        if target < 1:
+            raise ValueError("invalid repetition matrix with zero determinant")
+
+        inv_pt = np.linalg.inv(self.P.T)
+        base_bound = max(1, int(np.max(np.abs(self.P))))
+        seen = {}
+        for bound in range(base_bound, max_bound + 1):
+            ranges = [range(-bound, bound + 1)] * 3
+            for m in itertools.product(*ranges):
+                q = np.asarray(m, dtype=float) @ inv_pt
+                q = wrap_reduced(q, centered=centered)
+                key = tuple(np.round(wrap_reduced(q, centered=False), 12))
+                if key not in seen:
+                    seen[key] = q
+                    if len(seen) == target:
+                        arr = np.array(list(seen.values()))
+                        return arr[np.lexsort((arr[:, 2], arr[:, 1], arr[:, 0]))]
+        raise RuntimeError("failed to enumerate all commensurate q points")
+
+    def nearest_commensurate(self, qpoint_reduced, grid=None, preserve_image=False):
+        q = np.asarray(qpoint_reduced, dtype=float)
+        if grid is None:
+            grid = self.commensurate_grid(centered=False)
+
+        q_search = wrap_reduced(q, centered=False) if preserve_image else q
+        deltas = np.array([reduced_delta(q_search, candidate) for candidate in grid])
+        cart_deltas = deltas @ self.reciprocal_primitive
+        distances = np.linalg.norm(cart_deltas, axis=1)
+        idx = int(np.argmin(distances))
+        nearest = q - deltas[idx] if preserve_image else grid[idx]
+
+        requested_cart = self.reduced_to_cartesian(q)[0]
+        nearest_cart = self.reduced_to_cartesian(nearest)[0]
+        supercell_index = self.supercell_indices(nearest)[0]
+        return QPointAdvice(
+            requested_reduced=np.array(q, dtype=float),
+            nearest_reduced=np.array(nearest, dtype=float),
+            requested_cartesian=requested_cart,
+            nearest_cartesian=nearest_cart,
+            is_commensurate=self.is_commensurate(q),
+            error_reduced=float(np.linalg.norm(reduced_delta(q, nearest))),
+            error_cartesian=float(distances[idx]),
+            integer_supercell_index=np.rint(supercell_index).astype(int),
+        )
+
+    def advise_qpoints(self, qpoints_reduced, preserve_image=False):
+        grid = self.commensurate_grid(centered=False)
+        return [
+            self.nearest_commensurate(q, grid=grid, preserve_image=preserve_image)
+            for q in np.atleast_2d(qpoints_reduced)
+        ]
+
+    def nearest_commensurate_cartesian(self, qpoint_cartesian, grid=None, preserve_image=False):
+        """Map one Cartesian experimental Q point to the nearest allowed q point."""
+
+        q_reduced = self.cartesian_to_reduced(qpoint_cartesian)[0]
+        return self.nearest_commensurate(q_reduced, grid=grid, preserve_image=preserve_image)
+
+    def advise_cartesian_qpoints(self, qpoints_cartesian, preserve_image=False):
+        """Map Cartesian experimental Q points to nearest commensurate q points."""
+
+        q_reduced = self.cartesian_to_reduced(qpoints_cartesian)
+        return self.advise_qpoints(q_reduced, preserve_image=preserve_image)
+
+    def advise_experimental_path(
+        self,
+        qpoints,
+        coordinates="reduced",
+        preserve_image=True,
+        suggest_supercell=True,
+    ):
+        """Return a full commensurability report for an experimental q path.
+
+        Parameters
+        ----------
+        qpoints
+            Requested q or Q points, either reduced coordinates in the primitive
+            reciprocal basis or Cartesian vectors in inverse Angstrom.
+        coordinates
+            ``"reduced"``/``"fractional"``/``"crystal"`` or
+            ``"cartesian"``/``"angstrom^-1"``.
+        preserve_image
+            Preserve the extended-zone reciprocal-lattice image when mapping to
+            the nearest commensurate point.  This should normally stay ``True``
+            for EELS, INS, and IXS comparison because form factors and basis
+            interference depend on the full ``Q = q + G``.
+        suggest_supercell
+            If ``True``, recommend diagonal primitive-cell repeats that would
+            make all requested reduced coordinates commensurate.
+        """
+
+        coordinate_key = str(coordinates).lower()
+        if coordinate_key in ("reduced", "fractional", "crystal"):
+            requested_reduced = np.atleast_2d(np.asarray(qpoints, dtype=float))
+            if requested_reduced.shape[1] != 3:
+                raise ValueError("reduced qpoints must have shape (num_qpoints, 3)")
+            coordinate_system = "reduced"
+        elif coordinate_key in ("cartesian", "cart", "angstrom^-1", "1/angstrom"):
+            requested_cartesian = np.atleast_2d(np.asarray(qpoints, dtype=float))
+            if requested_cartesian.shape[1] != 3:
+                raise ValueError("Cartesian qpoints must have shape (num_qpoints, 3)")
+            requested_reduced = self.cartesian_to_reduced(requested_cartesian)
+            coordinate_system = "cartesian"
+        else:
+            raise ValueError("coordinates must be 'reduced' or 'cartesian'")
+
+        advice = self.advise_qpoints(requested_reduced, preserve_image=preserve_image)
+        suggested = (
+            suggest_diagonal_supercell(requested_reduced)
+            if suggest_supercell
+            else np.ones(3, dtype=int)
+        )
+        return QAdvisorReport(
+            coordinate_system=coordinate_system,
+            preserve_image=bool(preserve_image),
+            requested_reduced=np.asarray([item.requested_reduced for item in advice], dtype=float),
+            nearest_reduced=np.asarray([item.nearest_reduced for item in advice], dtype=float),
+            requested_cartesian=np.asarray([item.requested_cartesian for item in advice], dtype=float),
+            nearest_cartesian=np.asarray([item.nearest_cartesian for item in advice], dtype=float),
+            is_commensurate=np.asarray([item.is_commensurate for item in advice], dtype=bool),
+            error_reduced=np.asarray([item.error_reduced for item in advice], dtype=float),
+            error_cartesian=np.asarray([item.error_cartesian for item in advice], dtype=float),
+            integer_supercell_indices=np.asarray(
+                [item.integer_supercell_index for item in advice],
+                dtype=int,
+            ),
+            suggested_diagonal_supercell=np.asarray(suggested, dtype=int),
+        )
+
+    def plan_extended_zone_q_path(
+        self,
+        qpoints,
+        coordinates="reduced",
+        q_policy="strict",
+        max_error_reduced=None,
+        max_error_cartesian=None,
+    ):
+        """Plan a pairwise extended-zone path for EELS, INS, or IXS.
+
+        The returned :class:`ExtendedZoneQPathPlan` contains the nearest allowed
+        extended-zone :math:`Q_i`, the folded commensurate :math:`q_i`, and the
+        integer reciprocal vector :math:`G_i` for each experimental point:
+
+        ``Q_i = q_i + G_i``.
+        """
+
+        report = self.advise_experimental_path(
+            qpoints,
+            coordinates=coordinates,
+            preserve_image=True,
+        )
+        policy = str(q_policy).lower()
+        if policy not in ("strict", "nearest"):
+            raise ValueError("q_policy must be 'strict' or 'nearest'")
+        if policy == "strict" and not report.all_commensurate:
+            raise ValueError("experimental Q path contains non-commensurate points")
+        if policy == "nearest":
+            if max_error_reduced is not None and report.max_error_reduced > max_error_reduced:
+                raise ValueError("nearest commensurate q exceeds max_error_reduced")
+            if max_error_cartesian is not None and report.max_error_cartesian > max_error_cartesian:
+                raise ValueError("nearest commensurate q exceeds max_error_cartesian")
+
+        Q_reduced = report.nearest_reduced
+        q_folded, g_vectors = split_extended_zone_qpoints(Q_reduced)
+        return ExtendedZoneQPathPlan(
+            report=report,
+            Q_reduced=Q_reduced,
+            Q_cartesian=report.nearest_cartesian,
+            qpoints_reduced=q_folded,
+            qpoints_cartesian=self.reduced_to_cartesian(q_folded),
+            g_vectors_reduced=g_vectors,
+            g_vectors_cartesian=self.reduced_to_cartesian(g_vectors),
+        )
+
+    def advise_map_q_axis(
+        self,
+        scattering_map,
+        start_qpoint,
+        end_qpoint,
+        coordinates="cartesian",
+        preserve_image=True,
+        suggest_supercell=True,
+    ):
+        """Advise Q points implied by a calibrated experimental map q axis.
+
+        ``scattering_map`` may be any object with a one-dimensional ``q_axis``
+        attribute, including :class:`pySED.compare_experiment.ScatteringMap`.
+        The vector endpoints define the reciprocal-space path corresponding to
+        the first and last q-axis values.
+        """
+
+        if not hasattr(scattering_map, "q_axis"):
+            raise TypeError("scattering_map must expose a q_axis attribute")
+        qpoints = qpoints_from_path_axis(scattering_map.q_axis, start_qpoint, end_qpoint)
+        return self.advise_experimental_path(
+            qpoints,
+            coordinates=coordinates,
+            preserve_image=preserve_image,
+            suggest_supercell=suggest_supercell,
+        )
+
+    def plan_map_q_axis(
+        self,
+        scattering_map,
+        start_qpoint,
+        end_qpoint,
+        coordinates="cartesian",
+        q_policy="strict",
+        max_error_reduced=None,
+        max_error_cartesian=None,
+    ):
+        """Plan ``Q=q+G`` points from an experimental map's calibrated q axis."""
+
+        if not hasattr(scattering_map, "q_axis"):
+            raise TypeError("scattering_map must expose a q_axis attribute")
+        qpoints = qpoints_from_path_axis(scattering_map.q_axis, start_qpoint, end_qpoint)
+        return self.plan_extended_zone_q_path(
+            qpoints,
+            coordinates=coordinates,
+            q_policy=q_policy,
+            max_error_reduced=max_error_reduced,
+            max_error_cartesian=max_error_cartesian,
+        )
+
+    def build_commensurate_path(self, start_reduced, end_reduced):
+        fractions = self._find_allowed_fractions(start_reduced, end_reduced)
+        if not fractions:
+            return np.zeros((0, 3)), np.zeros((0,), dtype=float)
+
+        start = np.asarray(start_reduced, dtype=float)
+        end = np.asarray(end_reduced, dtype=float)
+        fvals = np.array([float(f) for f in fractions])
+        qpoints = np.array([start + f * (end - start) for f in fvals])
+        qpoints = np.where(np.isclose(qpoints, 0.0, atol=1e-14), 0.0, qpoints)
+        return qpoints, fvals
+
+    def write_phonopy_qpoints(self, qpoints_reduced, path):
+        q = np.atleast_2d(np.asarray(qpoints_reduced, dtype=float))
+        if not self.validate_qpoints(q):
+            raise ValueError("all phonopy q points must be commensurate with the MD supercell")
+        np.savetxt(path, q, fmt="%.10f")
+
+    def _find_allowed_fractions(self, start_reduced, end_reduced):
+        start = np.array([self._as_fraction(x) for x in start_reduced])
+        end = np.array([self._as_fraction(x) for x in end_reduced])
+        if np.all(start == end):
+            return [Fraction(0, 1)]
+
+        start_sc = start @ self.P.T
+        delta_sc = (end - start) @ self.P.T
+        possible = None
+        for a, b in zip(start_sc, delta_sc):
+            values = self._solve_integer_line(a, b)
+            if values is None:
+                continue
+            if not values:
+                return []
+            possible = set(values) if possible is None else possible & set(values)
+        return sorted(possible) if possible else []
+
+    @staticmethod
+    def _solve_integer_line(a, b):
+        if b == 0:
+            return None if a.denominator == 1 else []
+
+        low, high = (a, a + b) if b > 0 else (a + b, a)
+        n_min = math.floor(float(low))
+        n_max = math.ceil(float(high))
+        vals = [Fraction(n - a, b) for n in range(n_min, n_max + 1)]
+        return [x for x in vals if 0 <= x <= 1]
+
+    @staticmethod
+    def _as_fraction(value, max_denominator=96, atol=1e-8):
+        frac = Fraction(str(float(value)))
+        simple = frac.limit_denominator(max_denominator)
+        if abs(float(simple) - float(value)) <= atol:
+            return simple
+        return frac
+
+
+def suggest_diagonal_supercell(qpoints_reduced, max_denominator=96):
+    """Suggest diagonal repeats so every supplied reduced q point is allowed."""
+
+    q = np.atleast_2d(np.asarray(qpoints_reduced, dtype=float))
+    repeats = []
+    for axis in range(3):
+        denom = 1
+        for val in q[:, axis]:
+            frac = Fraction(str(float(val))).limit_denominator(max_denominator)
+            denom = _lcm(denom, frac.denominator)
+        repeats.append(denom)
+    return np.asarray(repeats, dtype=int)

--- a/pySED/quantum_correction.py
+++ b/pySED/quantum_correction.py
@@ -1,0 +1,114 @@
+"""Quantum detailed-balance corrections for classical scattering spectra."""
+
+import numpy as np
+
+
+PLANCK_MEV_THZ = 4.135667696
+"""Planck constant expressed as meV per THz."""
+
+BOLTZMANN_MEV_PER_K = 0.08617333262145
+"""Boltzmann constant expressed as meV/K."""
+
+WAVENUMBER_MEV = 0.1239841984332003
+"""Energy of one inverse centimeter expressed in meV."""
+
+
+def energy_axis_to_mev(axis, unit="thz"):
+    """Convert an energy/frequency axis to signed meV values."""
+
+    values = np.asarray(axis, dtype=float)
+    unit_key = str(unit).lower().replace("_", "-")
+    if unit_key in ("mev", "millielectronvolt", "millielectronvolts"):
+        return values
+    if unit_key in ("ev", "electronvolt", "electronvolts"):
+        return values * 1000.0
+    if unit_key in ("thz", "frequency-thz", "hz-thz"):
+        return values * PLANCK_MEV_THZ
+    if unit_key in ("cm-1", "cm^-1", "wavenumber", "wavenumbers"):
+        return values * WAVENUMBER_MEV
+    raise ValueError("unit must be 'thz', 'meV', 'eV', or 'cm-1'")
+
+
+def energy_axis_from_mev(energy_mev, unit="thz"):
+    """Convert signed meV values to the requested unit."""
+
+    values = np.asarray(energy_mev, dtype=float)
+    unit_key = str(unit).lower().replace("_", "-")
+    if unit_key in ("mev", "millielectronvolt", "millielectronvolts"):
+        return values
+    if unit_key in ("ev", "electronvolt", "electronvolts"):
+        return values / 1000.0
+    if unit_key in ("thz", "frequency-thz", "hz-thz"):
+        return values / PLANCK_MEV_THZ
+    if unit_key in ("cm-1", "cm^-1", "wavenumber", "wavenumbers"):
+        return values / WAVENUMBER_MEV
+    raise ValueError("unit must be 'thz', 'meV', 'eV', or 'cm-1'")
+
+
+def convert_energy_axis(axis, source_unit="thz", target_unit="meV"):
+    """Convert an axis between supported frequency/energy units."""
+
+    return energy_axis_from_mev(
+        energy_axis_to_mev(axis, unit=source_unit),
+        unit=target_unit,
+    )
+
+
+def classical_to_quantum_factor(axis, temperature, unit="thz"):
+    """Return the harmonic classical-to-quantum correction factor.
+
+    The factor is
+
+    ``x / (1 - exp(-x))``, where ``x = E / (k_B T)``.
+
+    For negative energy transfers the same signed expression obeys detailed
+    balance.  The zero-energy limit is evaluated with the Taylor expansion.
+    """
+
+    if temperature is None:
+        return np.ones_like(np.asarray(axis, dtype=float))
+    if temperature <= 0:
+        raise ValueError("temperature must be positive")
+
+    energy_mev = energy_axis_to_mev(axis, unit=unit)
+    x = energy_mev / (BOLTZMANN_MEV_PER_K * float(temperature))
+    factor = np.empty_like(x, dtype=float)
+    small = np.abs(x) < 1e-8
+    factor[small] = 1.0 + 0.5 * x[small] + (x[small] ** 2) / 12.0
+    with np.errstate(over="ignore", invalid="ignore"):
+        factor[~small] = x[~small] / (-np.expm1(-x[~small]))
+    return factor
+
+
+def bose_population(axis, temperature, unit="thz"):
+    """Return the Bose-Einstein population for positive energy magnitudes."""
+
+    if temperature <= 0:
+        raise ValueError("temperature must be positive")
+    energy_mev = np.abs(energy_axis_to_mev(axis, unit=unit))
+    x = energy_mev / (BOLTZMANN_MEV_PER_K * float(temperature))
+    out = np.empty_like(x, dtype=float)
+    zero = x == 0
+    out[zero] = np.inf
+    with np.errstate(over="ignore", divide="ignore", invalid="ignore"):
+        out[~zero] = 1.0 / np.expm1(x[~zero])
+    return out
+
+
+def apply_quantum_correction(intensity, axis, temperature, unit="thz", axis_index=-1):
+    """Multiply a spectrum or map by the harmonic quantum correction factor."""
+
+    arr = np.asarray(intensity, dtype=float)
+    factor = classical_to_quantum_factor(axis, temperature, unit=unit)
+    if factor.ndim != 1:
+        raise ValueError("axis must be one-dimensional")
+    axis_index = int(axis_index)
+    if axis_index < 0:
+        axis_index += arr.ndim
+    if axis_index < 0 or axis_index >= arr.ndim:
+        raise ValueError("axis_index is outside intensity dimensions")
+    if arr.shape[axis_index] != factor.size:
+        raise ValueError("axis length must match intensity dimension")
+    shape = [1] * arr.ndim
+    shape[axis_index] = factor.size
+    return arr * factor.reshape(shape)

--- a/pySED/scattering_export.py
+++ b/pySED/scattering_export.py
@@ -1,0 +1,192 @@
+"""Export helpers for paper-ready scattering workflow bundles."""
+
+from pathlib import Path
+import csv
+import json
+
+import numpy as np
+
+from pySED.compare_experiment import (
+    comparison_summary,
+    map_value_records,
+    write_map_comparison_report,
+)
+from pySED.visibility_diagnostics import diagnose_mode_visibility
+
+
+def _json_safe(value):
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, float):
+        return value if np.isfinite(value) else None
+    return value
+
+
+def _write_records_csv(path, records):
+    records = list(records)
+    fieldnames = list(records[0].keys()) if records else []
+    with open(path, "w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        if fieldnames:
+            writer.writeheader()
+            writer.writerows(records)
+
+
+def _q_advice_records(q_advice):
+    records = []
+    for index, advice in enumerate(q_advice or []):
+        records.append(
+            {
+                "index": int(index),
+                "is_commensurate": bool(advice.is_commensurate),
+                "error_reduced": float(advice.error_reduced),
+                "error_cartesian": float(advice.error_cartesian),
+                "requested_reduced_1": float(advice.requested_reduced[0]),
+                "requested_reduced_2": float(advice.requested_reduced[1]),
+                "requested_reduced_3": float(advice.requested_reduced[2]),
+                "nearest_reduced_1": float(advice.nearest_reduced[0]),
+                "nearest_reduced_2": float(advice.nearest_reduced[1]),
+                "nearest_reduced_3": float(advice.nearest_reduced[2]),
+                "requested_cartesian_1": float(advice.requested_cartesian[0]),
+                "requested_cartesian_2": float(advice.requested_cartesian[1]),
+                "requested_cartesian_3": float(advice.requested_cartesian[2]),
+                "nearest_cartesian_1": float(advice.nearest_cartesian[0]),
+                "nearest_cartesian_2": float(advice.nearest_cartesian[1]),
+                "nearest_cartesian_3": float(advice.nearest_cartesian[2]),
+                "integer_supercell_index_1": int(advice.integer_supercell_index[0]),
+                "integer_supercell_index_2": int(advice.integer_supercell_index[1]),
+                "integer_supercell_index_3": int(advice.integer_supercell_index[2]),
+            }
+        )
+    return records
+
+
+def _q_error_source(result):
+    q_plan = getattr(result, "q_plan", None)
+    if q_plan is not None:
+        return q_plan.report
+    return getattr(result, "q_advice", None)
+
+
+def workflow_export_summary(result, diagnostics=None):
+    """Return a JSON-ready summary for a scattering workflow result."""
+
+    summary = {
+        "workflow_type": type(result).__name__,
+        "has_q_plan": getattr(result, "q_plan", None) is not None,
+        "has_comparison": getattr(result, "comparison", None) is not None,
+        "has_visibility": hasattr(result, "visibility"),
+        "has_scattering_map": getattr(result, "scattering_map", None) is not None,
+    }
+    q_plan = getattr(result, "q_plan", None)
+    if q_plan is not None:
+        summary["q_plan"] = q_plan.report.summary()
+    elif getattr(result, "q_advice", None):
+        q_advice = result.q_advice
+        summary["q_advice"] = {
+            "num_points": len(q_advice),
+            "num_commensurate": int(sum(bool(item.is_commensurate) for item in q_advice)),
+            "max_error_reduced": float(max((item.error_reduced for item in q_advice), default=0.0)),
+            "max_error_cartesian": float(max((item.error_cartesian for item in q_advice), default=0.0)),
+        }
+    if getattr(result, "eigen_sed", None) is not None:
+        summary["eigen_sed_metadata"] = dict(result.eigen_sed.metadata)
+    if getattr(result, "dsf", None) is not None:
+        summary["dsf_metadata"] = dict(result.dsf.metadata)
+    if getattr(result, "partial_dsf", None) is not None:
+        summary["partial_dsf_metadata"] = dict(result.partial_dsf.metadata)
+    if getattr(result, "current", None) is not None:
+        summary["current_metadata"] = dict(result.current.metadata)
+    if getattr(result, "scattering_map", None) is not None:
+        summary["scattering_map_metadata"] = dict(result.scattering_map.metadata)
+        summary["scattering_map_shape"] = list(result.scattering_map.intensity.shape)
+    if getattr(result, "comparison", None) is not None:
+        summary["comparison"] = comparison_summary(result.comparison)
+    if diagnostics is not None:
+        summary["visibility_reason_counts"] = diagnostics.reason_counts()
+    return _json_safe(summary)
+
+
+def write_scattering_workflow_bundle(
+    result,
+    output_dir,
+    prefix="workflow",
+    atom_labels=None,
+    mode_labels=None,
+    include_all_visibility=True,
+    visibility_relative_threshold=None,
+    linecut_q_indices=None,
+    linecut_energy_indices=None,
+    write_scattering_map=True,
+):
+    """Write a reproducible bundle for a DSF/EELS/INS/IXS workflow result.
+
+    The bundle gathers q-advisor decisions, folded phonopy q points, simulated
+    maps, visibility diagnostics, and experimental comparison tables when those
+    objects are present on ``result``.
+    """
+
+    output = Path(output_dir)
+    output.mkdir(parents=True, exist_ok=True)
+    prefix = str(prefix)
+    written = {}
+
+    diagnostics = None
+    if hasattr(result, "visibility"):
+        diagnostics = diagnose_mode_visibility(
+            result.visibility,
+            q_advice=_q_error_source(result),
+            atom_labels=atom_labels,
+            mode_labels=mode_labels,
+        )
+        diagnostics_path = output / ("%s_visibility_diagnostics.csv" % prefix)
+        diagnostics.write_csv(
+            diagnostics_path,
+            include_all=include_all_visibility,
+            relative_threshold=visibility_relative_threshold,
+        )
+        written["visibility_diagnostics"] = str(diagnostics_path)
+
+    q_plan = getattr(result, "q_plan", None)
+    if q_plan is not None:
+        q_plan_path = output / ("%s_q_plan.csv" % prefix)
+        q_plan.write_csv(q_plan_path)
+        written["q_plan"] = str(q_plan_path)
+        phonopy_path = output / ("%s_phonopy_qpoints.dat" % prefix)
+        q_plan.write_phonopy_qpoints(phonopy_path)
+        written["phonopy_qpoints"] = str(phonopy_path)
+    elif getattr(result, "q_advice", None):
+        q_advice_path = output / ("%s_q_advice.csv" % prefix)
+        _write_records_csv(q_advice_path, _q_advice_records(result.q_advice))
+        written["q_advice"] = str(q_advice_path)
+
+    if write_scattering_map and getattr(result, "scattering_map", None) is not None:
+        map_path = output / ("%s_scattering_map.csv" % prefix)
+        _write_records_csv(
+            map_path,
+            map_value_records(result.scattering_map, value_name="intensity"),
+        )
+        written["scattering_map"] = str(map_path)
+
+    if getattr(result, "comparison", None) is not None:
+        comparison_paths = write_map_comparison_report(
+            result.comparison,
+            output,
+            prefix="%s_comparison" % prefix,
+            linecut_q_indices=linecut_q_indices,
+            linecut_energy_indices=linecut_energy_indices,
+        )
+        written.update({"comparison_%s" % key: value for key, value in comparison_paths.items()})
+
+    summary = workflow_export_summary(result, diagnostics=diagnostics)
+    summary_path = output / ("%s_summary.json" % prefix)
+    with open(summary_path, "w", encoding="utf-8") as handle:
+        json.dump(summary, handle, indent=2, sort_keys=True)
+    written["summary"] = str(summary_path)
+    return written

--- a/pySED/scattering_input.py
+++ b/pySED/scattering_input.py
@@ -1,0 +1,288 @@
+"""Input-file bridge for experiment-facing scattering workflows.
+
+This module keeps ``input_SED.in`` parsing separate from the numerical
+scattering APIs.  The first CLI-facing mode is the q-advisor because every
+finite-trajectory SED/DSF/EELS calculation needs the same commensurability
+decision before spectra are computed.
+"""
+
+from pathlib import Path
+
+import numpy as np
+
+from pySED.q_advisor import QAdvisor, qpoints_from_mesh, qpoints_from_path_segments
+
+
+class ScatteringInputError(ValueError):
+    """Error raised for invalid ``input_SED.in`` scattering settings."""
+
+    def __init__(self, message, written_files=None):
+        super().__init__(message)
+        self.written_files = written_files or {}
+
+
+def _input_relative_path(params, path_value):
+    path = Path(path_value)
+    if path.is_absolute():
+        return path
+    input_path = Path(getattr(params, "input_file", "input_SED.in"))
+    return input_path.parent / path
+
+
+def _output_prefix(params):
+    prefix = getattr(params, "scattering_output_prefix", None)
+    if prefix:
+        return Path(prefix)
+    return Path("%s_scattering" % getattr(params, "out_files_name", "pySED"))
+
+
+def _ensure_output_parent(path):
+    parent = Path(path).parent
+    if str(parent) not in ("", "."):
+        parent.mkdir(parents=True, exist_ok=True)
+
+
+def build_q_advisor_from_input(params):
+    """Build :class:`pySED.q_advisor.QAdvisor` from parsed input parameters."""
+
+    if not hasattr(params, "prim_unitcell"):
+        raise ScatteringInputError("scattering mode requires prim_unitcell in input_SED.in")
+
+    primitive = np.asarray(params.prim_unitcell, dtype=float)
+    if primitive.shape != (3, 3):
+        raise ScatteringInputError("prim_unitcell must contain 9 numeric values")
+
+    supercell_dim = np.asarray(getattr(params, "supercell_dim", [1, 1, 1]), dtype=float)
+    if supercell_dim.shape != (3,):
+        raise ScatteringInputError("supercell_dim must contain 3 integer repeats")
+    if np.any(supercell_dim <= 0):
+        raise ScatteringInputError("supercell_dim values must be positive")
+
+    supercell_cell = np.diag(supercell_dim) @ primitive
+    return QAdvisor(primitive, supercell_cell)
+
+
+def build_scattering_qpoints_from_input(params):
+    """Return requested Q points and source metadata from parsed input."""
+
+    option = str(getattr(params, "scattering_qpoints_option", "path")).lower()
+
+    if option in ("mesh", "q_mesh", "selected_mesh"):
+        mesh = qpoints_from_mesh(
+            getattr(params, "scattering_q_mesh_H", 0.0),
+            getattr(params, "scattering_q_mesh_K", 0.0),
+            getattr(params, "scattering_q_mesh_L", 0.0),
+        )
+        return mesh.qpoints_reduced, {
+            "source": "mesh",
+            "mesh_shape": mesh.mesh_shape,
+        }
+
+    if option in ("file", "q_file"):
+        q_file = getattr(params, "scattering_q_file", None)
+        if not q_file:
+            raise ScatteringInputError(
+                "scattering_qpoints_option = file requires scattering_q_file"
+            )
+        path = _input_relative_path(params, q_file)
+        qpoints = np.loadtxt(path, dtype=float)
+        qpoints = np.asarray(qpoints, dtype=float).reshape(-1, 3)
+        return qpoints, {"source": "file", "path": str(path)}
+
+    if option in ("points", "inline", "direct"):
+        qpoints = getattr(params, "scattering_qpoints", None)
+        if qpoints is None:
+            raise ScatteringInputError(
+                "scattering_qpoints_option = points requires scattering_qpoints"
+            )
+        return np.asarray(qpoints, dtype=float).reshape(-1, 3), {"source": "points"}
+
+    if option in ("path", "q_path"):
+        if not hasattr(params, "q_path"):
+            raise ScatteringInputError(
+                "scattering_qpoints_option = path requires num_qpaths and q_path"
+            )
+
+        vertices = np.asarray(params.q_path, dtype=float)
+        if vertices.ndim != 2 or vertices.shape[1] != 3 or vertices.shape[0] < 2:
+            raise ScatteringInputError("q_path must contain at least two 3D vertices")
+
+        steps = getattr(params, "scattering_q_path_steps", None)
+        if steps is None:
+            return vertices, {"source": "path_vertices", "num_segments": vertices.shape[0] - 1}
+
+        steps = np.asarray(steps, dtype=int).ravel()
+        num_segments = vertices.shape[0] - 1
+        if steps.size == 1:
+            steps = np.repeat(steps[0], num_segments)
+        if steps.size != num_segments:
+            raise ScatteringInputError(
+                "scattering_q_path_steps must have one value or num_qpaths values"
+            )
+
+        path = qpoints_from_path_segments(
+            starts=vertices[:-1],
+            ends=vertices[1:],
+            steps=steps,
+            endpoint=False,
+        )
+        qpoints = np.vstack([path.qpoints_reduced, vertices[-1].reshape(1, 3)])
+        return qpoints, {
+            "source": "path",
+            "num_segments": num_segments,
+            "segment_steps": steps.tolist(),
+        }
+
+    raise ScatteringInputError(
+        "scattering_qpoints_option must be path, mesh, file, or points"
+    )
+
+
+def _trajectory_frame_count(params):
+    total_steps = int(getattr(params, "total_num_steps", 0) or 0)
+    stride = int(getattr(params, "output_data_stride", 0) or 0)
+    if total_steps > 0 and stride > 0:
+        return max(1, total_steps // stride)
+    return None
+
+
+def _enforce_q_policy(report, params):
+    policy = str(getattr(params, "scattering_q_policy", "strict")).lower()
+    if policy not in ("strict", "nearest"):
+        raise ScatteringInputError("scattering_q_policy must be strict or nearest")
+
+    if policy == "strict" and not report.all_commensurate:
+        raise ScatteringInputError(
+            "non-commensurate Q points found: %d/%d are commensurate; "
+            "set scattering_q_policy = nearest to use nearest points, or enlarge "
+            "supercell_dim according to the q-advisor summary"
+            % (report.num_commensurate, report.num_points)
+        )
+
+    max_error_reduced = getattr(params, "scattering_max_error_reduced", None)
+    if max_error_reduced is not None and report.max_error_reduced > max_error_reduced:
+        raise ScatteringInputError(
+            "nearest commensurate Q exceeds scattering_max_error_reduced"
+        )
+
+    max_error_cartesian = getattr(params, "scattering_max_error_cartesian", None)
+    if max_error_cartesian is not None and report.max_error_cartesian > max_error_cartesian:
+        raise ScatteringInputError(
+            "nearest commensurate Q exceeds scattering_max_error_cartesian"
+        )
+
+
+def _write_q_advisor_summary(path, report, q_source, efficiency, params):
+    lines = [
+        "pySED scattering q-advisor summary",
+        "",
+        "scattering_mode = %s" % getattr(params, "scattering_mode", "q_advisor"),
+        "q_source = %s" % q_source.get("source", "unknown"),
+        "coordinates = %s" % getattr(params, "scattering_qpoint_coordinates", "reduced"),
+        "q_policy = %s" % getattr(params, "scattering_q_policy", "strict"),
+        "preserve_image = %s" % bool(getattr(params, "scattering_preserve_image", True)),
+        "num_points = %d" % report.num_points,
+        "num_commensurate = %d" % report.num_commensurate,
+        "all_commensurate = %s" % report.all_commensurate,
+        "max_error_reduced = %.12g" % report.max_error_reduced,
+        "max_error_cartesian = %.12g" % report.max_error_cartesian,
+        "suggested_diagonal_supercell = %s" % report.suggested_diagonal_supercell.tolist(),
+        "",
+        "Q-point report",
+        report.to_table(),
+    ]
+    if efficiency is not None:
+        lines.extend(["", "Selected-Q efficiency", efficiency.to_table()])
+
+    _ensure_output_parent(path)
+    Path(path).write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def run_q_advisor_from_input(params):
+    """Run q-advisor mode from ``input_SED.in`` and write report artifacts."""
+
+    advisor = build_q_advisor_from_input(params)
+    qpoints, q_source = build_scattering_qpoints_from_input(params)
+    coordinates = getattr(params, "scattering_qpoint_coordinates", "reduced")
+    preserve_image = bool(getattr(params, "scattering_preserve_image", True))
+    report = advisor.advise_experimental_path(
+        qpoints,
+        coordinates=coordinates,
+        preserve_image=preserve_image,
+    )
+
+    prefix = _output_prefix(params)
+    written = {}
+
+    csv_path = prefix.with_name(prefix.name + "_q_advisor.csv")
+    _ensure_output_parent(csv_path)
+    report.write_csv(csv_path)
+    written["q_advisor_csv"] = str(csv_path)
+
+    nearest_path = prefix.with_name(prefix.name + "_nearest_qpoints_reduced.dat")
+    _ensure_output_parent(nearest_path)
+    np.savetxt(nearest_path, report.nearest_reduced, fmt="%.10f")
+    written["nearest_qpoints_reduced"] = str(nearest_path)
+
+    requested_path = prefix.with_name(prefix.name + "_requested_qpoints_reduced.dat")
+    _ensure_output_parent(requested_path)
+    np.savetxt(requested_path, report.requested_reduced, fmt="%.10f")
+    written["requested_qpoints_reduced"] = str(requested_path)
+
+    efficiency = None
+    if bool(getattr(params, "scattering_report_efficiency", True)):
+        efficiency = advisor.estimate_selected_q_efficiency(
+            report.nearest_reduced,
+            num_frames=_trajectory_frame_count(params),
+            num_atoms=int(getattr(params, "num_atoms", 0) or 0) or None,
+        )
+
+    summary_path = prefix.with_name(prefix.name + "_q_advisor_summary.txt")
+    _write_q_advisor_summary(summary_path, report, q_source, efficiency, params)
+    written["summary"] = str(summary_path)
+
+    try:
+        _enforce_q_policy(report, params)
+    except ScatteringInputError as exc:
+        exc.written_files.update(written)
+        raise
+
+    plan = advisor.plan_extended_zone_q_path(
+        qpoints,
+        coordinates=coordinates,
+        q_policy=getattr(params, "scattering_q_policy", "strict"),
+        max_error_reduced=getattr(params, "scattering_max_error_reduced", None),
+        max_error_cartesian=getattr(params, "scattering_max_error_cartesian", None),
+    )
+
+    plan_csv_path = prefix.with_name(prefix.name + "_extended_zone_plan.csv")
+    _ensure_output_parent(plan_csv_path)
+    plan.write_csv(plan_csv_path)
+    written["extended_zone_plan"] = str(plan_csv_path)
+
+    phonopy_path = prefix.with_name(prefix.name + "_phonopy_qpoints_reduced.dat")
+    _ensure_output_parent(phonopy_path)
+    plan.write_phonopy_qpoints(phonopy_path)
+    written["phonopy_qpoints_reduced"] = str(phonopy_path)
+
+    return {
+        "advisor": advisor,
+        "report": report,
+        "q_source": q_source,
+        "efficiency": efficiency,
+        "extended_zone_plan": plan,
+        "written_files": written,
+    }
+
+
+def run_scattering_from_input(params):
+    """Dispatch input-file scattering modes."""
+
+    mode = str(getattr(params, "scattering_mode", "q_advisor")).lower()
+    if mode in ("q_advisor", "qadvisor", "advisor"):
+        return run_q_advisor_from_input(params)
+
+    raise ScatteringInputError(
+        "input_SED.in currently supports scattering_mode = q_advisor; "
+        "use the Python scattering APIs for DSF/EELS until their CLI modes are added"
+    )

--- a/pySED/scattering_kernel.py
+++ b/pySED/scattering_kernel.py
@@ -1,0 +1,171 @@
+"""Shared low-level kernels for pySED scattering calculations.
+
+The functions here are deliberately small CPU/NumPy kernels.  They centralize
+the operations that will later be natural targets for optional CuPy or
+Numba-CUDA implementations: phase construction, density amplitudes, time FFT
+power spectra, and block statistics.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+from scipy.fft import fft, fftfreq
+
+
+@dataclass
+class KernelBackend:
+    name: str
+    xp: object
+    fft: object
+    fftfreq: object
+    asnumpy: object
+
+
+@dataclass
+class FrequencyGrid:
+    frequencies_thz: np.ndarray
+    freq_slice: slice
+
+
+def resolve_backend(backend="cpu"):
+    """Resolve a scattering kernel backend.
+
+    ``"cpu"`` and ``"numpy"`` use NumPy/SciPy and are always available.
+    ``"cupy"`` and ``"gpu"`` request CuPy/CuPyX.  CuPy is optional and must be
+    installed by the user with the wheel that matches their CUDA runtime.
+    """
+
+    if isinstance(backend, KernelBackend):
+        return backend
+    if backend is None or backend in ("cpu", "numpy"):
+        return KernelBackend(
+            name="cpu",
+            xp=np,
+            fft=fft,
+            fftfreq=fftfreq,
+            asnumpy=lambda array: np.asarray(array),
+        )
+    if backend in ("cupy", "gpu"):
+        try:
+            import cupy as cp
+            from cupyx.scipy.fft import fft as cupy_fft
+            from cupyx.scipy.fft import fftfreq as cupy_fftfreq
+        except ImportError as exc:
+            raise ImportError(
+                "CuPy backend requested but CuPy is not installed. Install the "
+                "CuPy package matching your CUDA runtime, or use backend='cpu'."
+            ) from exc
+
+        return KernelBackend(
+            name="cupy",
+            xp=cp,
+            fft=cupy_fft,
+            fftfreq=cupy_fftfreq,
+            asnumpy=cp.asnumpy,
+        )
+    raise ValueError("backend must be 'cpu', 'numpy', 'cupy', or 'gpu'")
+
+
+def to_numpy(array, backend="cpu"):
+    """Move a backend array to a NumPy array."""
+
+    return resolve_backend(backend).asnumpy(array)
+
+
+def as_blocks(n_frames, num_blocks):
+    """Split a trajectory length into equally sized contiguous blocks."""
+
+    if num_blocks < 1:
+        raise ValueError("num_blocks must be at least 1")
+    block_size = n_frames // num_blocks
+    if block_size < 2:
+        raise ValueError("each block must contain at least two frames")
+    return [(i * block_size, (i + 1) * block_size) for i in range(num_blocks)]
+
+
+def positive_frequency_slice(num_frames):
+    """Return the positive-frequency half used by pySED spectra."""
+
+    return slice(0, num_frames // 2)
+
+
+def frequency_grid(block_size, dt, positive_only=True, backend="cpu"):
+    """Return THz frequencies and the slice used for spectral outputs."""
+
+    kernel = resolve_backend(backend)
+    freq = kernel.fftfreq(block_size, dt) / 1e12
+    freq_slice = positive_frequency_slice(block_size) if positive_only else slice(None)
+    return FrequencyGrid(frequencies_thz=to_numpy(freq[freq_slice], kernel), freq_slice=freq_slice)
+
+
+def standard_error(samples, backend="cpu"):
+    """Return the standard error over the first axis."""
+
+    kernel = resolve_backend(backend)
+    xp = kernel.xp
+    samples = xp.asarray(samples, dtype=float)
+    if samples.shape[0] < 2:
+        return np.zeros(samples.shape[1:], dtype=float)
+    sem = xp.std(samples, axis=0, ddof=1) / xp.sqrt(samples.shape[0])
+    return to_numpy(sem, kernel)
+
+
+def phase_factors(positions_block, q_vec, backend="cpu"):
+    """Return ``exp(i Q dot r_i(t))`` for one trajectory block and Q vector."""
+
+    kernel = resolve_backend(backend)
+    xp = kernel.xp
+    block = xp.asarray(positions_block, dtype=float)
+    q_vec = xp.asarray(q_vec, dtype=float)
+    if block.ndim != 3 or block.shape[2] != 3:
+        raise ValueError("positions_block must have shape (num_frames, num_atoms, 3)")
+    if q_vec.shape != (3,):
+        raise ValueError("q_vec must have shape (3,)")
+    return xp.exp(1j * xp.tensordot(block, q_vec, axes=([2], [0])))
+
+
+def density_amplitude(positions_block, q_vec, weights=None, backend="cpu"):
+    """Return weighted density amplitude ``rho(Q,t)`` for one block."""
+
+    phase = phase_factors(positions_block, q_vec, backend=backend)
+    return density_amplitude_from_phase(phase, weights, backend=backend)
+
+
+def density_amplitude_from_phase(phase, weights=None, backend="cpu"):
+    """Return weighted density amplitude from precomputed phase factors."""
+
+    kernel = resolve_backend(backend)
+    xp = kernel.xp
+    phase = xp.asarray(phase)
+    if phase.ndim != 2:
+        raise ValueError("phase must have shape (num_frames, num_atoms)")
+    if weights is None:
+        weights = xp.ones(phase.shape[1], dtype=float)
+    weights = xp.asarray(weights)
+    if weights.shape != (phase.shape[1],):
+        raise ValueError("weights length must match number of atoms")
+    return phase @ weights
+
+
+def fft_power(signal, axis=0, norm="forward", backend="cpu"):
+    """Return ``abs(FFT(signal))**2`` with the configured FFT normalization."""
+
+    kernel = resolve_backend(backend)
+    xp = kernel.xp
+    signal = xp.asarray(signal)
+    return xp.abs(kernel.fft(signal, axis=axis, norm=norm)) ** 2
+
+
+def circular_autocorrelation(signal, backend="cpu"):
+    """Return circular autocorrelation used for finite-block reference DSF."""
+
+    kernel = resolve_backend(backend)
+    xp = kernel.xp
+    signal = xp.asarray(signal)
+    if signal.ndim != 1:
+        raise ValueError("signal must be one-dimensional")
+    corr = xp.empty(signal.size, dtype=complex)
+    signal_conj = xp.conjugate(signal)
+    for lag in range(signal.size):
+        corr[lag] = xp.mean(xp.roll(signal, -lag) * signal_conj)
+    return corr

--- a/pySED/scattering_plot.py
+++ b/pySED/scattering_plot.py
@@ -1,0 +1,240 @@
+"""Plotting helpers for paper-ready scattering-map comparisons."""
+
+from pathlib import Path
+
+import numpy as np
+
+from pySED.compare_experiment import MapComparison, ScatteringMap, linecut
+
+
+def _import_pyplot():
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError as exc:
+        raise ImportError("matplotlib is required for pySED.scattering_plot") from exc
+    return plt
+
+
+def _map_extent(scattering_map):
+    q = np.asarray(scattering_map.q_axis, dtype=float)
+    energy = np.asarray(scattering_map.energy_axis, dtype=float)
+    return [float(q[0]), float(q[-1]), float(energy[0]), float(energy[-1])]
+
+
+def _save_if_requested(fig, save_path=None, dpi=300):
+    if save_path is None:
+        return None
+    path = Path(save_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(path, dpi=dpi, bbox_inches="tight")
+    return path
+
+
+def plot_scattering_map(
+    scattering_map,
+    ax=None,
+    title=None,
+    cmap="magma",
+    vmin=None,
+    vmax=None,
+    q_label="Q path",
+    energy_label="Energy",
+    colorbar=True,
+    save_path=None,
+    dpi=300,
+):
+    """Plot a single q-energy scattering map.
+
+    Returns ``(fig, ax, image)`` so callers can further tune labels, ticks, or
+    panel annotations before saving.
+    """
+
+    if not isinstance(scattering_map, ScatteringMap):
+        raise TypeError("scattering_map must be a ScatteringMap")
+
+    plt = _import_pyplot()
+    if ax is None:
+        fig, ax = plt.subplots(figsize=(4.2, 3.2), constrained_layout=True)
+    else:
+        fig = ax.figure
+
+    image = ax.imshow(
+        scattering_map.intensity.T,
+        origin="lower",
+        aspect="auto",
+        extent=_map_extent(scattering_map),
+        cmap=cmap,
+        vmin=vmin,
+        vmax=vmax,
+        interpolation="nearest",
+    )
+    ax.set_xlabel(q_label)
+    ax.set_ylabel(energy_label)
+    if title:
+        ax.set_title(title)
+    if colorbar:
+        fig.colorbar(image, ax=ax, pad=0.02)
+
+    _save_if_requested(fig, save_path=save_path, dpi=dpi)
+    return fig, ax, image
+
+
+def plot_linecuts(
+    simulated_map,
+    experimental_map=None,
+    q_indices=None,
+    ax=None,
+    labels=None,
+    energy_label="Energy",
+    intensity_label="Intensity",
+    save_path=None,
+    dpi=300,
+):
+    """Plot energy line cuts at selected q indices."""
+
+    if not isinstance(simulated_map, ScatteringMap):
+        raise TypeError("simulated_map must be a ScatteringMap")
+    if experimental_map is not None and not isinstance(experimental_map, ScatteringMap):
+        raise TypeError("experimental_map must be a ScatteringMap")
+
+    n_q = simulated_map.q_axis.size
+    if q_indices is None:
+        q_indices = [0, n_q // 2, n_q - 1] if n_q > 2 else list(range(n_q))
+    q_indices = [int(index) for index in q_indices]
+    if any(index < 0 or index >= n_q for index in q_indices):
+        raise ValueError("q_indices must be valid simulated-map q indices")
+
+    if experimental_map is not None:
+        if experimental_map.q_axis.size != n_q:
+            raise ValueError("experimental_map must be aligned to simulated_map before plotting linecuts")
+        if experimental_map.energy_axis.shape != simulated_map.energy_axis.shape:
+            raise ValueError("experimental_map energy axis must match simulated_map")
+
+    plt = _import_pyplot()
+    if ax is None:
+        fig, ax = plt.subplots(figsize=(4.2, 3.0), constrained_layout=True)
+    else:
+        fig = ax.figure
+
+    label_prefix = labels or {"simulated": "sim", "experimental": "exp"}
+    for index in q_indices:
+        q_value = simulated_map.q_axis[index]
+        sim_label = "%s q=%.4g" % (label_prefix.get("simulated", "sim"), q_value)
+        ax.plot(
+            simulated_map.energy_axis,
+            linecut(simulated_map.intensity, index, axis=0),
+            label=sim_label,
+            linewidth=1.6,
+        )
+        if experimental_map is not None:
+            exp_label = "%s q=%.4g" % (label_prefix.get("experimental", "exp"), q_value)
+            ax.plot(
+                experimental_map.energy_axis,
+                linecut(experimental_map.intensity, index, axis=0),
+                label=exp_label,
+                linewidth=1.0,
+                linestyle="--",
+            )
+
+    ax.set_xlabel(energy_label)
+    ax.set_ylabel(intensity_label)
+    ax.legend(frameon=False, fontsize="small")
+    _save_if_requested(fig, save_path=save_path, dpi=dpi)
+    return fig, ax
+
+
+def plot_map_comparison(
+    comparison,
+    q_label="Q path",
+    energy_label="Energy",
+    cmap="magma",
+    residual_cmap="coolwarm",
+    q_indices=None,
+    figsize=(10.0, 6.2),
+    save_path=None,
+    dpi=300,
+):
+    """Create a simulated/experimental/residual map and line-cut figure."""
+
+    if not isinstance(comparison, MapComparison):
+        raise TypeError("comparison must be a MapComparison")
+    if comparison.simulated_map is None or comparison.experimental_map is None:
+        raise ValueError("comparison must include simulated_map and experimental_map")
+
+    plt = _import_pyplot()
+    fig = plt.figure(figsize=figsize, constrained_layout=True)
+    grid = fig.add_gridspec(2, 3, height_ratios=(1.0, 0.82))
+    ax_sim = fig.add_subplot(grid[0, 0])
+    ax_exp = fig.add_subplot(grid[0, 1])
+    ax_res = fig.add_subplot(grid[0, 2])
+    ax_line = fig.add_subplot(grid[1, :])
+
+    sim_map = ScatteringMap(
+        comparison.simulated_map.q_axis,
+        comparison.simulated_map.energy_axis,
+        comparison.simulated,
+        metadata=comparison.simulated_map.metadata,
+    )
+    exp_map = ScatteringMap(
+        comparison.experimental_map.q_axis,
+        comparison.experimental_map.energy_axis,
+        comparison.experimental,
+        metadata=comparison.experimental_map.metadata,
+    )
+    res_map = ScatteringMap(
+        comparison.experimental_map.q_axis,
+        comparison.experimental_map.energy_axis,
+        comparison.residual,
+        metadata={"source": "comparison residual"},
+    )
+
+    shared_max = np.nanmax(np.abs(np.concatenate([comparison.simulated.ravel(), comparison.experimental.ravel()])))
+    shared_vmax = None if shared_max == 0 else float(shared_max)
+    plot_scattering_map(
+        sim_map,
+        ax=ax_sim,
+        title="Simulated",
+        cmap=cmap,
+        vmin=0.0 if shared_vmax is not None else None,
+        vmax=shared_vmax,
+        q_label=q_label,
+        energy_label=energy_label,
+    )
+    plot_scattering_map(
+        exp_map,
+        ax=ax_exp,
+        title="Experimental",
+        cmap=cmap,
+        vmin=0.0 if shared_vmax is not None else None,
+        vmax=shared_vmax,
+        q_label=q_label,
+        energy_label=energy_label,
+    )
+
+    res_abs = np.nanmax(np.abs(comparison.residual))
+    res_limit = None if res_abs == 0 else float(res_abs)
+    plot_scattering_map(
+        res_map,
+        ax=ax_res,
+        title="Residual",
+        cmap=residual_cmap,
+        vmin=-res_limit if res_limit is not None else None,
+        vmax=res_limit,
+        q_label=q_label,
+        energy_label=energy_label,
+    )
+    plot_linecuts(
+        sim_map,
+        experimental_map=exp_map,
+        q_indices=q_indices,
+        ax=ax_line,
+        energy_label=energy_label,
+    )
+
+    fig.suptitle(
+        "RMSE %.4g, MAE %.4g, corr %.4g"
+        % (comparison.rmse, comparison.mae, comparison.correlation),
+        fontsize=11,
+    )
+    _save_if_requested(fig, save_path=save_path, dpi=dpi)
+    return fig

--- a/pySED/scattering_workflow.py
+++ b/pySED/scattering_workflow.py
@@ -1,0 +1,1139 @@
+"""High-level workflows for experiment-facing scattering maps."""
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from pySED.compare_experiment import ScatteringMap, prepare_map_comparison
+from pySED.dsf import compute_current_correlations, compute_dsf, compute_partial_dsf
+from pySED.electron_kinematics import eels_qpoints_from_angle_axis
+from pySED.eels import build_eels_map_from_mode_spectra, compute_mode_visibility_decomposition
+from pySED.eigen_sed import compute_eigen_sed
+from pySED.mode_visibility import build_one_phonon_map_from_mode_spectra
+from pySED.mode_visibility import compute_one_phonon_visibility
+from pySED.quantum_correction import convert_energy_axis
+from pySED.q_advisor import QAdvisor
+
+
+@dataclass
+class EELSWorkflowResult:
+    """Outputs from the MD-to-extended-zone-EELS workflow."""
+
+    advisor: QAdvisor
+    q_advice: list
+    eigen_sed: object
+    visibility: object
+    eels_map: object
+    scattering_map: ScatteringMap
+    comparison: object = None
+    q_plan: object = None
+
+
+@dataclass
+class DSFWorkflowResult:
+    """Outputs from q-advised DSF calculation."""
+
+    advisor: QAdvisor
+    q_advice: list
+    qpoints_reduced: np.ndarray
+    qpoints_cartesian: np.ndarray
+    dsf: object
+    scattering_map: ScatteringMap = None
+    comparison: object = None
+
+
+@dataclass
+class PartialDSFWorkflowResult:
+    """Outputs from q-advised species-partial DSF calculation."""
+
+    advisor: QAdvisor
+    q_advice: list
+    qpoints_reduced: np.ndarray
+    qpoints_cartesian: np.ndarray
+    partial_dsf: object
+    scattering_map: ScatteringMap = None
+    comparison: object = None
+
+
+@dataclass
+class CurrentCorrelationWorkflowResult:
+    """Outputs from q-advised longitudinal/transverse current spectra."""
+
+    advisor: QAdvisor
+    q_advice: list
+    qpoints_reduced: np.ndarray
+    qpoints_cartesian: np.ndarray
+    current: object
+    scattering_map: ScatteringMap = None
+    comparison: object = None
+
+
+@dataclass
+class OnePhononWorkflowResult:
+    """Outputs from eigen-SED-to-INS/IXS one-phonon workflow."""
+
+    advisor: QAdvisor
+    q_advice: list
+    eigen_sed: object
+    visibility: object
+    one_phonon_map: object
+    scattering_map: ScatteringMap
+    comparison: object = None
+    q_plan: object = None
+
+
+def q_path_axis(qpoints_cartesian):
+    """Return cumulative path distance for ordered Cartesian Q points."""
+
+    qpoints = np.atleast_2d(np.asarray(qpoints_cartesian, dtype=float))
+    if qpoints.shape[1] != 3:
+        raise ValueError("qpoints_cartesian must have shape (num_qpoints, 3)")
+    if qpoints.shape[0] == 1:
+        return np.zeros(1, dtype=float)
+    steps = np.linalg.norm(np.diff(qpoints, axis=0), axis=1)
+    return np.concatenate([[0.0], np.cumsum(steps)])
+
+
+def _requested_qpoints_to_advice(advisor, qpoints, qpoint_coordinates):
+    coordinate_key = str(qpoint_coordinates).lower()
+    if coordinate_key in ("reduced", "fractional", "crystal"):
+        q_reduced = np.atleast_2d(np.asarray(qpoints, dtype=float))
+        if q_reduced.shape[1] != 3:
+            raise ValueError("reduced qpoints must have shape (num_qpoints, 3)")
+        advice = advisor.advise_qpoints(q_reduced, preserve_image=True)
+        return q_reduced, advisor.reduced_to_cartesian(q_reduced), advice
+
+    if coordinate_key in ("cartesian", "cart", "angstrom^-1", "1/angstrom"):
+        q_cart = np.atleast_2d(np.asarray(qpoints, dtype=float))
+        if q_cart.shape[1] != 3:
+            raise ValueError("Cartesian qpoints must have shape (num_qpoints, 3)")
+        q_reduced = advisor.cartesian_to_reduced(q_cart)
+        advice = advisor.advise_cartesian_qpoints(q_cart, preserve_image=True)
+        return q_reduced, q_cart, advice
+
+    raise ValueError("qpoint_coordinates must be 'reduced' or 'cartesian'")
+
+
+def _enforce_q_policy(q_advice, q_policy, max_error_reduced=None, max_error_cartesian=None):
+    policy = str(q_policy).lower()
+    if policy not in ("strict", "nearest"):
+        raise ValueError("q_policy must be 'strict' or 'nearest'")
+
+    non_commensurate = [advice for advice in q_advice if not advice.is_commensurate]
+    if policy == "strict" and non_commensurate:
+        worst = max(non_commensurate, key=lambda item: item.error_cartesian)
+        raise ValueError(
+            "requested q points are not commensurate with the MD supercell; "
+            "largest Cartesian error to nearest allowed Q is %.6g" % worst.error_cartesian
+        )
+
+    if policy == "nearest":
+        if max_error_reduced is not None:
+            too_large = [advice for advice in q_advice if advice.error_reduced > max_error_reduced]
+            if too_large:
+                raise ValueError("nearest commensurate q exceeds max_error_reduced")
+        if max_error_cartesian is not None:
+            too_large = [advice for advice in q_advice if advice.error_cartesian > max_error_cartesian]
+            if too_large:
+                raise ValueError("nearest commensurate q exceeds max_error_cartesian")
+
+    return policy
+
+
+def compute_dsf_workflow(
+    positions,
+    qpoints,
+    primitive_cell,
+    supercell_cell,
+    dt,
+    qpoint_coordinates="reduced",
+    q_policy="strict",
+    max_error_reduced=None,
+    max_error_cartesian=None,
+    map_component="total",
+    q_axis=None,
+    experimental_map=None,
+    sigma_q=None,
+    sigma_energy=None,
+    normalization="max",
+    quantum_temperature=None,
+    output_energy_unit="thz",
+    **dsf_kwargs,
+):
+    """Validate or map requested Q points before computing DSF.
+
+    ``q_policy="strict"`` rejects non-commensurate points.  ``"nearest"`` maps
+    each requested point to the nearest commensurate point while preserving the
+    extended-zone reciprocal-lattice image, so ``Q = q + G`` is not folded back
+    to the first Brillouin zone.
+    """
+
+    advisor = QAdvisor(primitive_cell, supercell_cell)
+    q_reduced, q_cartesian, q_advice = _requested_qpoints_to_advice(
+        advisor,
+        qpoints,
+        qpoint_coordinates,
+    )
+    policy = _enforce_q_policy(
+        q_advice,
+        q_policy,
+        max_error_reduced=max_error_reduced,
+        max_error_cartesian=max_error_cartesian,
+    )
+
+    if policy == "nearest":
+        q_reduced = np.asarray([advice.nearest_reduced for advice in q_advice], dtype=float)
+        q_cartesian = np.asarray([advice.nearest_cartesian for advice in q_advice], dtype=float)
+
+    result = compute_dsf(positions, q_cartesian, dt, **dsf_kwargs)
+    result.metadata.update(
+        {
+            "q_policy": policy,
+            "qpoint_coordinates": qpoint_coordinates,
+            "q_advisor": "finite-supercell commensurability enforced",
+            "max_q_error_reduced": max((advice.error_reduced for advice in q_advice), default=0.0),
+            "max_q_error_cartesian": max((advice.error_cartesian for advice in q_advice), default=0.0),
+        }
+    )
+
+    scattering_map = dsf_to_scattering_map(
+        result,
+        component=map_component,
+        q_axis=q_axis,
+        source_energy_unit="thz",
+        output_energy_unit=output_energy_unit,
+    )
+    comparison = None
+    if experimental_map is not None:
+        comparison = prepare_map_comparison(
+            scattering_map,
+            experimental_map,
+            sigma_q=sigma_q,
+            sigma_energy=sigma_energy,
+            normalization=normalization,
+            quantum_temperature=quantum_temperature,
+            energy_unit=output_energy_unit,
+        )
+
+    return DSFWorkflowResult(
+        advisor=advisor,
+        q_advice=q_advice,
+        qpoints_reduced=q_reduced,
+        qpoints_cartesian=q_cartesian,
+        dsf=result,
+        scattering_map=scattering_map,
+        comparison=comparison,
+    )
+
+
+def compute_partial_dsf_workflow(
+    positions,
+    qpoints,
+    primitive_cell,
+    supercell_cell,
+    dt,
+    atom_types,
+    qpoint_coordinates="reduced",
+    q_policy="strict",
+    max_error_reduced=None,
+    max_error_cartesian=None,
+    map_component="weighted_total",
+    species_pair=None,
+    complex_part="real",
+    q_axis=None,
+    experimental_map=None,
+    sigma_q=None,
+    sigma_energy=None,
+    normalization="max",
+    quantum_temperature=None,
+    output_energy_unit="thz",
+    **partial_kwargs,
+):
+    """Validate/map requested Q points before computing species-partial DSF."""
+
+    advisor = QAdvisor(primitive_cell, supercell_cell)
+    q_reduced, q_cartesian, q_advice = _requested_qpoints_to_advice(
+        advisor,
+        qpoints,
+        qpoint_coordinates,
+    )
+    policy = _enforce_q_policy(
+        q_advice,
+        q_policy,
+        max_error_reduced=max_error_reduced,
+        max_error_cartesian=max_error_cartesian,
+    )
+
+    if policy == "nearest":
+        q_reduced = np.asarray([advice.nearest_reduced for advice in q_advice], dtype=float)
+        q_cartesian = np.asarray([advice.nearest_cartesian for advice in q_advice], dtype=float)
+
+    result = compute_partial_dsf(
+        positions,
+        q_cartesian,
+        dt,
+        atom_types=atom_types,
+        **partial_kwargs,
+    )
+    result.metadata.update(
+        {
+            "q_policy": policy,
+            "qpoint_coordinates": qpoint_coordinates,
+            "q_advisor": "finite-supercell commensurability enforced",
+            "max_q_error_reduced": max((advice.error_reduced for advice in q_advice), default=0.0),
+            "max_q_error_cartesian": max((advice.error_cartesian for advice in q_advice), default=0.0),
+        }
+    )
+
+    scattering_map = partial_dsf_to_scattering_map(
+        result,
+        component=map_component,
+        species_pair=species_pair,
+        complex_part=complex_part,
+        q_axis=q_axis,
+        source_energy_unit="thz",
+        output_energy_unit=output_energy_unit,
+    )
+    comparison = None
+    if experimental_map is not None:
+        comparison = prepare_map_comparison(
+            scattering_map,
+            experimental_map,
+            sigma_q=sigma_q,
+            sigma_energy=sigma_energy,
+            normalization=normalization,
+            quantum_temperature=quantum_temperature,
+            energy_unit=output_energy_unit,
+        )
+
+    return PartialDSFWorkflowResult(
+        advisor=advisor,
+        q_advice=q_advice,
+        qpoints_reduced=q_reduced,
+        qpoints_cartesian=q_cartesian,
+        partial_dsf=result,
+        scattering_map=scattering_map,
+        comparison=comparison,
+    )
+
+
+def compute_current_correlation_workflow(
+    positions,
+    velocities,
+    qpoints,
+    primitive_cell,
+    supercell_cell,
+    dt,
+    qpoint_coordinates="reduced",
+    q_policy="strict",
+    max_error_reduced=None,
+    max_error_cartesian=None,
+    map_component="longitudinal",
+    q_axis=None,
+    experimental_map=None,
+    sigma_q=None,
+    sigma_energy=None,
+    normalization="max",
+    quantum_temperature=None,
+    output_energy_unit="thz",
+    **current_kwargs,
+):
+    """Validate/map requested Q points before computing current spectra."""
+
+    advisor = QAdvisor(primitive_cell, supercell_cell)
+    q_reduced, q_cartesian, q_advice = _requested_qpoints_to_advice(
+        advisor,
+        qpoints,
+        qpoint_coordinates,
+    )
+    policy = _enforce_q_policy(
+        q_advice,
+        q_policy,
+        max_error_reduced=max_error_reduced,
+        max_error_cartesian=max_error_cartesian,
+    )
+
+    if policy == "nearest":
+        q_reduced = np.asarray([advice.nearest_reduced for advice in q_advice], dtype=float)
+        q_cartesian = np.asarray([advice.nearest_cartesian for advice in q_advice], dtype=float)
+
+    result = compute_current_correlations(
+        positions,
+        velocities,
+        q_cartesian,
+        dt,
+        **current_kwargs,
+    )
+    result.metadata.update(
+        {
+            "q_policy": policy,
+            "qpoint_coordinates": qpoint_coordinates,
+            "q_advisor": "finite-supercell commensurability enforced",
+            "max_q_error_reduced": max((advice.error_reduced for advice in q_advice), default=0.0),
+            "max_q_error_cartesian": max((advice.error_cartesian for advice in q_advice), default=0.0),
+        }
+    )
+
+    scattering_map = current_correlation_to_scattering_map(
+        result,
+        component=map_component,
+        q_axis=q_axis,
+        source_energy_unit="thz",
+        output_energy_unit=output_energy_unit,
+    )
+    comparison = None
+    if experimental_map is not None:
+        comparison = prepare_map_comparison(
+            scattering_map,
+            experimental_map,
+            sigma_q=sigma_q,
+            sigma_energy=sigma_energy,
+            normalization=normalization,
+            quantum_temperature=quantum_temperature,
+            energy_unit=output_energy_unit,
+        )
+
+    return CurrentCorrelationWorkflowResult(
+        advisor=advisor,
+        q_advice=q_advice,
+        qpoints_reduced=q_reduced,
+        qpoints_cartesian=q_cartesian,
+        current=result,
+        scattering_map=scattering_map,
+        comparison=comparison,
+    )
+
+
+def dsf_to_scattering_map(
+    dsf_result,
+    component="total",
+    q_axis=None,
+    source_energy_unit="thz",
+    output_energy_unit="thz",
+):
+    """Convert a DSF result component into a q-energy scattering map."""
+
+    component_key = str(component).lower()
+    if component_key not in ("total", "coherent", "incoherent"):
+        raise ValueError("component must be 'total', 'coherent', or 'incoherent'")
+
+    intensity = np.asarray(getattr(dsf_result, component_key), dtype=float)
+    if intensity.ndim != 2:
+        raise ValueError("DSF component must have shape (num_q, num_energy)")
+
+    q_axis_source = "user supplied"
+    if q_axis is None:
+        q_axis = q_path_axis(dsf_result.qpoints_cartesian)
+        q_axis_source = "Cartesian path distance"
+    q_axis = np.asarray(q_axis, dtype=float)
+    if q_axis.shape != (intensity.shape[0],):
+        raise ValueError("q_axis length must match number of q points")
+
+    energy_axis = np.asarray(dsf_result.frequencies_thz, dtype=float)
+    if output_energy_unit != source_energy_unit:
+        energy_axis = convert_energy_axis(
+            energy_axis,
+            source_unit=source_energy_unit,
+            target_unit=output_energy_unit,
+        )
+
+    metadata = {
+        "source": "pySED DSFResult",
+        "component": component_key,
+        "q_axis": q_axis_source,
+        "energy_unit": output_energy_unit,
+        "experiment": dsf_result.metadata.get("experiment") if dsf_result.metadata else None,
+    }
+    return ScatteringMap(q_axis, energy_axis, intensity, metadata)
+
+
+def _species_pair_indices(species, species_pair):
+    if species_pair is None:
+        raise ValueError("species_pair must be supplied when component='partial'")
+    if len(species_pair) != 2:
+        raise ValueError("species_pair must contain two labels or indices")
+
+    indices = []
+    for item in species_pair:
+        if isinstance(item, (int, np.integer)):
+            index = int(item)
+            if not 0 <= index < len(species):
+                raise ValueError("species_pair index is outside the available species")
+            indices.append(index)
+        else:
+            label = str(item)
+            if label not in species:
+                raise ValueError("species_pair label %s is not present in partial DSF" % label)
+            indices.append(species.index(label))
+    return tuple(indices)
+
+
+def partial_dsf_to_scattering_map(
+    partial_result,
+    component="weighted_total",
+    species_pair=None,
+    complex_part="real",
+    q_axis=None,
+    source_energy_unit="thz",
+    output_energy_unit="thz",
+):
+    """Convert a partial DSF component into a q-energy scattering map.
+
+    ``component="weighted_total"`` returns the probe-weighted coherent total.
+    ``component="partial"`` selects one species pair from the complex partial
+    matrix and returns its real part, imaginary part, or magnitude.
+    """
+
+    component_key = str(component).lower()
+    if component_key in ("weighted_total", "total", "coherent"):
+        intensity = np.asarray(partial_result.weighted_total, dtype=float)
+        selected_pair = None
+        selected_part = None
+    elif component_key in ("partial", "species_pair", "pair"):
+        pair_indices = _species_pair_indices(partial_result.species, species_pair)
+        selected = np.asarray(partial_result.partial[:, pair_indices[0], pair_indices[1], :])
+        part_key = str(complex_part).lower()
+        if part_key == "real":
+            intensity = selected.real
+        elif part_key in ("imag", "imaginary"):
+            intensity = selected.imag
+        elif part_key in ("abs", "magnitude"):
+            intensity = np.abs(selected)
+        else:
+            raise ValueError("complex_part must be 'real', 'imag', or 'abs'")
+        selected_pair = (
+            partial_result.species[pair_indices[0]],
+            partial_result.species[pair_indices[1]],
+        )
+        selected_part = part_key
+    else:
+        raise ValueError("component must be 'weighted_total' or 'partial'")
+
+    if intensity.ndim != 2:
+        raise ValueError("partial DSF map component must have shape (num_q, num_energy)")
+
+    q_axis_source = "user supplied"
+    if q_axis is None:
+        q_axis = q_path_axis(partial_result.qpoints_cartesian)
+        q_axis_source = "Cartesian path distance"
+    q_axis = np.asarray(q_axis, dtype=float)
+    if q_axis.shape != (intensity.shape[0],):
+        raise ValueError("q_axis length must match number of q points")
+
+    energy_axis = np.asarray(partial_result.frequencies_thz, dtype=float)
+    if output_energy_unit != source_energy_unit:
+        energy_axis = convert_energy_axis(
+            energy_axis,
+            source_unit=source_energy_unit,
+            target_unit=output_energy_unit,
+        )
+
+    metadata = {
+        "source": "pySED PartialDSFResult",
+        "component": component_key,
+        "species_pair": selected_pair,
+        "complex_part": selected_part,
+        "q_axis": q_axis_source,
+        "energy_unit": output_energy_unit,
+    }
+    return ScatteringMap(q_axis, energy_axis, intensity, metadata)
+
+
+def current_correlation_to_scattering_map(
+    current_result,
+    component="longitudinal",
+    q_axis=None,
+    source_energy_unit="thz",
+    output_energy_unit="thz",
+):
+    """Convert a longitudinal/transverse current spectrum to a q-energy map."""
+
+    component_key = str(component).lower()
+    if component_key not in ("longitudinal", "transverse"):
+        raise ValueError("component must be 'longitudinal' or 'transverse'")
+
+    intensity = np.asarray(getattr(current_result, component_key), dtype=float)
+    if intensity.ndim != 2:
+        raise ValueError("current spectrum must have shape (num_q, num_energy)")
+
+    q_axis_source = "user supplied"
+    if q_axis is None:
+        q_axis = q_path_axis(current_result.qpoints_cartesian)
+        q_axis_source = "Cartesian path distance"
+    q_axis = np.asarray(q_axis, dtype=float)
+    if q_axis.shape != (intensity.shape[0],):
+        raise ValueError("q_axis length must match number of q points")
+
+    energy_axis = np.asarray(current_result.frequencies_thz, dtype=float)
+    if output_energy_unit != source_energy_unit:
+        energy_axis = convert_energy_axis(
+            energy_axis,
+            source_unit=source_energy_unit,
+            target_unit=output_energy_unit,
+        )
+
+    metadata = {
+        "source": "pySED CurrentCorrelationResult",
+        "component": component_key,
+        "q_axis": q_axis_source,
+        "energy_unit": output_energy_unit,
+    }
+    return ScatteringMap(q_axis, energy_axis, intensity, metadata)
+
+
+def eels_map_to_scattering_map(
+    eels_map,
+    g_index=0,
+    q_axis=None,
+    source_energy_unit="thz",
+    output_energy_unit="thz",
+):
+    """Select one extended-zone G branch as a 2D q-energy map.
+
+    The returned q axis is the cumulative Cartesian path distance unless a
+    user-supplied ``q_axis`` is provided.
+    """
+
+    intensity = np.asarray(eels_map.intensity, dtype=float)
+    if intensity.ndim != 3:
+        raise ValueError("eels_map intensity must have shape (num_q, num_g, num_energy)")
+    if not 0 <= int(g_index) < intensity.shape[1]:
+        raise ValueError("g_index is outside the available extended-zone branches")
+
+    q_cart = np.asarray(eels_map.Q_cartesian[:, int(g_index), :], dtype=float)
+    q_axis_source = "user supplied"
+    if q_axis is None:
+        q_axis = q_path_axis(q_cart)
+        q_axis_source = "Cartesian path distance"
+    q_axis = np.asarray(q_axis, dtype=float)
+    if q_axis.shape != (intensity.shape[0],):
+        raise ValueError("q_axis length must match number of q points")
+
+    energy_axis = np.asarray(eels_map.energy_axis, dtype=float)
+    if output_energy_unit != source_energy_unit:
+        energy_axis = convert_energy_axis(
+            energy_axis,
+            source_unit=source_energy_unit,
+            target_unit=output_energy_unit,
+        )
+
+    metadata = {
+        "source": "pySED EELSMap",
+        "g_index": int(g_index),
+        "q_axis": q_axis_source,
+        "energy_unit": output_energy_unit,
+    }
+    return ScatteringMap(q_axis, energy_axis, intensity[:, int(g_index), :], metadata)
+
+
+def one_phonon_map_to_scattering_map(
+    one_phonon_map,
+    g_index=0,
+    q_axis=None,
+    source_energy_unit="thz",
+    output_energy_unit="thz",
+):
+    """Select one extended-zone G branch from an INS/IXS one-phonon map."""
+
+    intensity = np.asarray(one_phonon_map.intensity, dtype=float)
+    if intensity.ndim != 3:
+        raise ValueError("one_phonon_map intensity must have shape (num_q, num_g, num_energy)")
+    if not 0 <= int(g_index) < intensity.shape[1]:
+        raise ValueError("g_index is outside the available extended-zone branches")
+
+    q_cart = np.asarray(one_phonon_map.Q_cartesian[:, int(g_index), :], dtype=float)
+    q_axis_source = "user supplied"
+    if q_axis is None:
+        q_axis = q_path_axis(q_cart)
+        q_axis_source = "Cartesian path distance"
+    q_axis = np.asarray(q_axis, dtype=float)
+    if q_axis.shape != (intensity.shape[0],):
+        raise ValueError("q_axis length must match number of q points")
+
+    energy_axis = np.asarray(one_phonon_map.energy_axis, dtype=float)
+    if output_energy_unit != source_energy_unit:
+        energy_axis = convert_energy_axis(
+            energy_axis,
+            source_unit=source_energy_unit,
+            target_unit=output_energy_unit,
+        )
+
+    metadata = {
+        "source": "pySED OnePhononMap",
+        "g_index": int(g_index),
+        "q_axis": q_axis_source,
+        "energy_unit": output_energy_unit,
+    }
+    return ScatteringMap(q_axis, energy_axis, intensity[:, int(g_index), :], metadata)
+
+
+def compute_one_phonon_workflow(
+    velocities,
+    unitcell_vectors,
+    basis_index,
+    masses,
+    primitive_cell,
+    supercell_cell,
+    eigenvectors,
+    basis_positions_reduced,
+    g_vectors_reduced,
+    dt,
+    atom_types=None,
+    experiment="neutron",
+    scattering_weights=None,
+    frequency_power=0,
+    num_blocks=1,
+    sed_backend="cpu",
+    target_qpoints_reduced=None,
+    pairwise_g_vectors=False,
+    g_index=0,
+    q_axis=None,
+    experimental_map=None,
+    sigma_q=None,
+    sigma_energy=None,
+    normalization="max",
+    quantum_temperature=None,
+    output_energy_unit="thz",
+):
+    """Run commensurate-q, eigen-SED, and one-phonon INS/IXS workflow."""
+
+    advisor = QAdvisor(primitive_cell, supercell_cell)
+    qpoints = np.asarray(eigenvectors.qpoints_reduced, dtype=float)
+    q_advice = advisor.advise_qpoints(qpoints)
+    if any(not advice.is_commensurate for advice in q_advice):
+        raise ValueError("eigenvector q points must be commensurate with the MD supercell")
+
+    eigen_sed = compute_eigen_sed(
+        velocities,
+        unitcell_vectors,
+        basis_index,
+        masses,
+        primitive_cell,
+        supercell_cell,
+        eigenvectors,
+        dt,
+        num_blocks=num_blocks,
+        target_qpoints=target_qpoints_reduced,
+        validate_q=True,
+        backend=sed_backend,
+    )
+    visibility = compute_one_phonon_visibility(
+        eigen_sed.qpoints_reduced,
+        g_vectors_reduced,
+        primitive_cell,
+        basis_positions_reduced,
+        masses,
+        eigenvectors.eigenvectors,
+        atom_types=atom_types,
+        experiment=experiment,
+        scattering_weights=scattering_weights,
+        mode_frequencies=eigenvectors.frequencies,
+        frequency_power=frequency_power,
+        pairwise_g_vectors=pairwise_g_vectors,
+    )
+    one_phonon_map = build_one_phonon_map_from_mode_spectra(
+        visibility,
+        eigen_sed.sed,
+        eigen_sed.frequencies_thz,
+    )
+    scattering_map = one_phonon_map_to_scattering_map(
+        one_phonon_map,
+        g_index=g_index,
+        q_axis=q_axis,
+        source_energy_unit="thz",
+        output_energy_unit=output_energy_unit,
+    )
+
+    comparison = None
+    if experimental_map is not None:
+        comparison = prepare_map_comparison(
+            scattering_map,
+            experimental_map,
+            sigma_q=sigma_q,
+            sigma_energy=sigma_energy,
+            normalization=normalization,
+            quantum_temperature=quantum_temperature,
+            energy_unit=output_energy_unit,
+        )
+
+    return OnePhononWorkflowResult(
+        advisor=advisor,
+        q_advice=q_advice,
+        eigen_sed=eigen_sed,
+        visibility=visibility,
+        one_phonon_map=one_phonon_map,
+        scattering_map=scattering_map,
+        comparison=comparison,
+    )
+
+
+def compute_one_phonon_workflow_from_q_path(
+    velocities,
+    unitcell_vectors,
+    basis_index,
+    masses,
+    primitive_cell,
+    supercell_cell,
+    eigenvectors,
+    basis_positions_reduced,
+    experimental_qpoints,
+    dt,
+    qpoint_coordinates="cartesian",
+    q_policy="strict",
+    max_error_reduced=None,
+    max_error_cartesian=None,
+    atom_types=None,
+    experiment="neutron",
+    scattering_weights=None,
+    frequency_power=0,
+    num_blocks=1,
+    sed_backend="cpu",
+    q_axis=None,
+    experimental_map=None,
+    sigma_q=None,
+    sigma_energy=None,
+    normalization="max",
+    quantum_temperature=None,
+    output_energy_unit="thz",
+):
+    """Run coherent INS/IXS one-phonon workflow from an experimental Q path."""
+
+    advisor = QAdvisor(primitive_cell, supercell_cell)
+    q_plan = advisor.plan_extended_zone_q_path(
+        experimental_qpoints,
+        coordinates=qpoint_coordinates,
+        q_policy=q_policy,
+        max_error_reduced=max_error_reduced,
+        max_error_cartesian=max_error_cartesian,
+    )
+    result = compute_one_phonon_workflow(
+        velocities,
+        unitcell_vectors,
+        basis_index,
+        masses,
+        primitive_cell,
+        supercell_cell,
+        eigenvectors,
+        basis_positions_reduced,
+        q_plan.g_vectors_reduced,
+        dt,
+        atom_types=atom_types,
+        experiment=experiment,
+        scattering_weights=scattering_weights,
+        frequency_power=frequency_power,
+        num_blocks=num_blocks,
+        sed_backend=sed_backend,
+        target_qpoints_reduced=q_plan.qpoints_reduced,
+        pairwise_g_vectors=True,
+        g_index=0,
+        q_axis=q_axis,
+        experimental_map=experimental_map,
+        sigma_q=sigma_q,
+        sigma_energy=sigma_energy,
+        normalization=normalization,
+        quantum_temperature=quantum_temperature,
+        output_energy_unit=output_energy_unit,
+    )
+    result.q_plan = q_plan
+    result.eigen_sed.metadata.update(
+        {
+            "q_plan": "experimental extended-zone Q path folded to commensurate q",
+            "q_policy": q_policy,
+            "max_q_error_reduced": q_plan.report.max_error_reduced,
+            "max_q_error_cartesian": q_plan.report.max_error_cartesian,
+        }
+    )
+    return result
+
+
+def compute_eels_workflow(
+    velocities,
+    unitcell_vectors,
+    basis_index,
+    masses,
+    primitive_cell,
+    supercell_cell,
+    eigenvectors,
+    basis_positions_reduced,
+    g_vectors_reduced,
+    dt,
+    num_blocks=1,
+    sed_backend="cpu",
+    target_qpoints_reduced=None,
+    electron_form_factors=None,
+    atom_types=None,
+    electron_form_factor_model="unit",
+    electron_form_factor_table=None,
+    electron_missing="raise",
+    pairwise_g_vectors=False,
+    g_index=0,
+    q_axis=None,
+    experimental_map=None,
+    sigma_q=None,
+    sigma_energy=None,
+    normalization="max",
+    quantum_temperature=None,
+    output_energy_unit="thz",
+):
+    """Run the commensurate-q, eigen-SED, and kinematic EELS workflow.
+
+    This function is intentionally a workflow wrapper around the lower-level
+    modules.  It keeps the paper-facing sequence explicit:
+
+    ``q_advisor -> eigen_sed -> EELS visibility -> extended-zone map``.
+    """
+
+    advisor = QAdvisor(primitive_cell, supercell_cell)
+    qpoints = np.asarray(eigenvectors.qpoints_reduced, dtype=float)
+    q_advice = advisor.advise_qpoints(qpoints)
+    if any(not advice.is_commensurate for advice in q_advice):
+        raise ValueError("eigenvector q points must be commensurate with the MD supercell")
+
+    eigen_sed = compute_eigen_sed(
+        velocities,
+        unitcell_vectors,
+        basis_index,
+        masses,
+        primitive_cell,
+        supercell_cell,
+        eigenvectors,
+        dt,
+        num_blocks=num_blocks,
+        target_qpoints=target_qpoints_reduced,
+        validate_q=True,
+        backend=sed_backend,
+    )
+
+    visibility = compute_mode_visibility_decomposition(
+        eigen_sed.qpoints_reduced,
+        g_vectors_reduced,
+        primitive_cell,
+        basis_positions_reduced,
+        masses,
+        eigenvectors.eigenvectors,
+        electron_form_factors=electron_form_factors,
+        atom_types=atom_types,
+        electron_form_factor_model=electron_form_factor_model,
+        electron_form_factor_table=electron_form_factor_table,
+        electron_missing=electron_missing,
+        pairwise_g_vectors=pairwise_g_vectors,
+    )
+    eels_map = build_eels_map_from_mode_spectra(
+        visibility,
+        eigen_sed.sed,
+        eigen_sed.frequencies_thz,
+    )
+    scattering_map = eels_map_to_scattering_map(
+        eels_map,
+        g_index=g_index,
+        q_axis=q_axis,
+        source_energy_unit="thz",
+        output_energy_unit=output_energy_unit,
+    )
+
+    comparison = None
+    if experimental_map is not None:
+        comparison = prepare_map_comparison(
+            scattering_map,
+            experimental_map,
+            sigma_q=sigma_q,
+            sigma_energy=sigma_energy,
+            normalization=normalization,
+            quantum_temperature=quantum_temperature,
+            energy_unit=output_energy_unit,
+        )
+
+    return EELSWorkflowResult(
+        advisor=advisor,
+        q_advice=q_advice,
+        eigen_sed=eigen_sed,
+        visibility=visibility,
+        eels_map=eels_map,
+        scattering_map=scattering_map,
+        comparison=comparison,
+    )
+
+
+def compute_eels_workflow_from_q_path(
+    velocities,
+    unitcell_vectors,
+    basis_index,
+    masses,
+    primitive_cell,
+    supercell_cell,
+    eigenvectors,
+    basis_positions_reduced,
+    experimental_qpoints,
+    dt,
+    qpoint_coordinates="cartesian",
+    q_policy="strict",
+    max_error_reduced=None,
+    max_error_cartesian=None,
+    num_blocks=1,
+    sed_backend="cpu",
+    electron_form_factors=None,
+    atom_types=None,
+    electron_form_factor_model="unit",
+    electron_form_factor_table=None,
+    electron_missing="raise",
+    q_axis=None,
+    experimental_map=None,
+    sigma_q=None,
+    sigma_energy=None,
+    normalization="max",
+    quantum_temperature=None,
+    output_energy_unit="thz",
+):
+    """Run the EELS workflow directly from an experimental extended-zone Q path.
+
+    This wrapper performs the full experiment-facing sequence:
+
+    ``experimental Q -> q_plan(Q=q+G) -> eigen-SED at folded q -> pairwise EELS map``.
+    """
+
+    advisor = QAdvisor(primitive_cell, supercell_cell)
+    q_plan = advisor.plan_extended_zone_q_path(
+        experimental_qpoints,
+        coordinates=qpoint_coordinates,
+        q_policy=q_policy,
+        max_error_reduced=max_error_reduced,
+        max_error_cartesian=max_error_cartesian,
+    )
+
+    result = compute_eels_workflow(
+        velocities,
+        unitcell_vectors,
+        basis_index,
+        masses,
+        primitive_cell,
+        supercell_cell,
+        eigenvectors,
+        basis_positions_reduced,
+        q_plan.g_vectors_reduced,
+        dt,
+        num_blocks=num_blocks,
+        sed_backend=sed_backend,
+        target_qpoints_reduced=q_plan.qpoints_reduced,
+        electron_form_factors=electron_form_factors,
+        atom_types=atom_types,
+        electron_form_factor_model=electron_form_factor_model,
+        electron_form_factor_table=electron_form_factor_table,
+        electron_missing=electron_missing,
+        pairwise_g_vectors=True,
+        g_index=0,
+        q_axis=q_axis,
+        experimental_map=experimental_map,
+        sigma_q=sigma_q,
+        sigma_energy=sigma_energy,
+        normalization=normalization,
+        quantum_temperature=quantum_temperature,
+        output_energy_unit=output_energy_unit,
+    )
+    result.q_plan = q_plan
+    result.eigen_sed.metadata.update(
+        {
+            "q_plan": "experimental extended-zone Q path folded to commensurate q",
+            "q_policy": q_policy,
+            "max_q_error_reduced": q_plan.report.max_error_reduced,
+            "max_q_error_cartesian": q_plan.report.max_error_cartesian,
+        }
+    )
+    return result
+
+
+def compute_eels_workflow_from_angle_axis(
+    velocities,
+    unitcell_vectors,
+    basis_index,
+    masses,
+    primitive_cell,
+    supercell_cell,
+    eigenvectors,
+    basis_positions_reduced,
+    angle_axis,
+    beam_energy_ev,
+    dt,
+    direction=(1.0, 0.0),
+    energy_loss_ev=0.0,
+    angle_unit="mrad",
+    include_longitudinal=False,
+    q_policy="strict",
+    max_error_reduced=None,
+    max_error_cartesian=None,
+    num_blocks=1,
+    sed_backend="cpu",
+    electron_form_factors=None,
+    atom_types=None,
+    electron_form_factor_model="unit",
+    electron_form_factor_table=None,
+    electron_missing="raise",
+    q_axis=None,
+    experimental_map=None,
+    sigma_q=None,
+    sigma_energy=None,
+    normalization="max",
+    quantum_temperature=None,
+    output_energy_unit="thz",
+):
+    """Run q-EELS workflow from a calibrated detector scattering-angle axis.
+
+    The angle axis is converted to Cartesian momentum transfer with
+    :func:`pySED.electron_kinematics.eels_qpoints_from_angle_axis`, then the
+    standard extended-zone q-path workflow is used.
+    """
+
+    experimental_qpoints = eels_qpoints_from_angle_axis(
+        angle_axis,
+        beam_energy_ev=beam_energy_ev,
+        direction=direction,
+        energy_loss_ev=energy_loss_ev,
+        angle_unit=angle_unit,
+        include_longitudinal=include_longitudinal,
+    )
+    result = compute_eels_workflow_from_q_path(
+        velocities=velocities,
+        unitcell_vectors=unitcell_vectors,
+        basis_index=basis_index,
+        masses=masses,
+        primitive_cell=primitive_cell,
+        supercell_cell=supercell_cell,
+        eigenvectors=eigenvectors,
+        basis_positions_reduced=basis_positions_reduced,
+        experimental_qpoints=experimental_qpoints,
+        dt=dt,
+        qpoint_coordinates="cartesian",
+        q_policy=q_policy,
+        max_error_reduced=max_error_reduced,
+        max_error_cartesian=max_error_cartesian,
+        num_blocks=num_blocks,
+        sed_backend=sed_backend,
+        electron_form_factors=electron_form_factors,
+        atom_types=atom_types,
+        electron_form_factor_model=electron_form_factor_model,
+        electron_form_factor_table=electron_form_factor_table,
+        electron_missing=electron_missing,
+        q_axis=q_axis,
+        experimental_map=experimental_map,
+        sigma_q=sigma_q,
+        sigma_energy=sigma_energy,
+        normalization=normalization,
+        quantum_temperature=quantum_temperature,
+        output_energy_unit=output_energy_unit,
+    )
+    result.eigen_sed.metadata.update(
+        {
+            "q_plan_source": "electron scattering angle axis",
+            "beam_energy_ev": float(beam_energy_ev),
+            "angle_unit": str(angle_unit),
+            "include_longitudinal_q": bool(include_longitudinal),
+        }
+    )
+    result.visibility.metadata.update(
+        {
+            "q_plan_source": "electron scattering angle axis",
+            "beam_energy_ev": float(beam_energy_ev),
+            "angle_unit": str(angle_unit),
+            "include_longitudinal_q": bool(include_longitudinal),
+        }
+    )
+    return result

--- a/pySED/validation.py
+++ b/pySED/validation.py
@@ -1,0 +1,522 @@
+"""Validation helpers for scattering implementations."""
+
+from dataclasses import dataclass
+import importlib
+import importlib.util
+import json
+import platform
+import sys
+
+import numpy as np
+
+from pySED.dsf import compute_coherent_dsf_via_correlation, compute_dsf
+from pySED.version import __version__
+
+
+@dataclass
+class DSFValidationCase:
+    """Small deterministic DSF validation problem."""
+
+    positions: np.ndarray
+    qpoints_cartesian: np.ndarray
+    coherent_weights: np.ndarray
+    dt: float
+    num_blocks: int = 4
+    description: str = "synthetic deterministic trajectory"
+
+
+@dataclass
+class SpectrumComparison:
+    """Metrics for comparing a pySED spectrum with an external reference."""
+
+    passed: bool
+    candidate_shape: tuple
+    reference_shape: tuple
+    normalization: str
+    scale_factor: float
+    rmse: float
+    mae: float
+    max_abs: float
+    normalized_rmse: float
+    correlation: float
+    peak_frequency_mae: float = None
+    reason: str = None
+
+    def to_dict(self):
+        return {
+            "passed": bool(self.passed),
+            "candidate_shape": tuple(self.candidate_shape),
+            "reference_shape": tuple(self.reference_shape),
+            "normalization": self.normalization,
+            "scale_factor": float(self.scale_factor),
+            "rmse": float(self.rmse),
+            "mae": float(self.mae),
+            "max_abs": float(self.max_abs),
+            "normalized_rmse": float(self.normalized_rmse),
+            "correlation": float(self.correlation),
+            "peak_frequency_mae": None
+            if self.peak_frequency_mae is None
+            else float(self.peak_frequency_mae),
+            "reason": self.reason,
+        }
+
+
+def synthetic_dsf_validation_case(num_frames=64):
+    """Return a deterministic trajectory and weighted Q points."""
+
+    time = np.arange(num_frames, dtype=float)
+    positions = np.zeros((num_frames, 3, 3), dtype=float)
+    positions[:, 0, 0] = 0.05 * np.sin(2 * np.pi * time / 16)
+    positions[:, 1, 0] = 0.50 + 0.08 * np.cos(2 * np.pi * time / 8)
+    positions[:, 1, 1] = 0.04 * np.sin(2 * np.pi * time / 16)
+    positions[:, 2, 2] = 0.25 + 0.03 * np.cos(2 * np.pi * time / 4)
+    qpoints = np.array([[2 * np.pi, 0.0, 0.0], [0.0, 2 * np.pi, 2 * np.pi]])
+    weights = np.array([[1.0, 2.0, 1.5], [0.5, 1.5, 2.5]])
+    return DSFValidationCase(
+        positions=positions,
+        qpoints_cartesian=qpoints,
+        coherent_weights=weights,
+        dt=1e-13,
+        num_blocks=4,
+    )
+
+
+def compute_pysed_validation_pair(case=None):
+    """Compute pySED direct and explicit-correlation DSF for one case."""
+
+    if case is None:
+        case = synthetic_dsf_validation_case()
+    direct = compute_dsf(
+        case.positions,
+        case.qpoints_cartesian,
+        case.dt,
+        experiment="custom",
+        coherent_weights=case.coherent_weights,
+        num_blocks=case.num_blocks,
+    )
+    reference = compute_coherent_dsf_via_correlation(
+        case.positions,
+        case.qpoints_cartesian,
+        case.dt,
+        coherent_weights=case.coherent_weights,
+        num_blocks=case.num_blocks,
+    )
+    return direct, reference
+
+
+def compare_arrays(candidate, reference, atol=1e-12, rtol=1e-12):
+    """Return scalar comparison metrics between two arrays."""
+
+    candidate = np.asarray(candidate)
+    reference = np.asarray(reference)
+    if candidate.shape != reference.shape:
+        return {
+            "passed": False,
+            "reason": "shape mismatch",
+            "candidate_shape": tuple(candidate.shape),
+            "reference_shape": tuple(reference.shape),
+        }
+    delta = candidate - reference
+    max_abs = float(np.nanmax(np.abs(delta))) if delta.size else 0.0
+    reference_norm = float(np.nanmax(np.abs(reference))) if reference.size else 0.0
+    scale = atol + rtol * reference_norm
+    return {
+        "passed": bool(max_abs <= scale),
+        "max_abs": max_abs,
+        "reference_max_abs": reference_norm,
+        "atol": float(atol),
+        "rtol": float(rtol),
+        "threshold": float(scale),
+    }
+
+
+def _interpolate_last_axis(values, source_frequencies, target_frequencies):
+    values = np.asarray(values, dtype=float)
+    source = np.asarray(source_frequencies, dtype=float)
+    target = np.asarray(target_frequencies, dtype=float)
+    if source.ndim != 1 or target.ndim != 1:
+        raise ValueError("frequency arrays must be one-dimensional")
+    if values.shape[-1] != source.size:
+        raise ValueError("source_frequencies length must match spectrum last axis")
+
+    flat = values.reshape(-1, values.shape[-1])
+    output = np.zeros((flat.shape[0], target.size), dtype=float)
+    order = np.argsort(source)
+    source_sorted = source[order]
+    for row_index, row in enumerate(flat):
+        output[row_index] = np.interp(target, source_sorted, row[order])
+    return output.reshape(values.shape[:-1] + (target.size,))
+
+
+def _least_squares_scale(candidate, reference):
+    numerator = float(np.sum(candidate * reference))
+    denominator = float(np.sum(candidate * candidate))
+    if denominator == 0.0:
+        return 1.0
+    return numerator / denominator
+
+
+def _peak_frequency_mae(candidate, reference, candidate_frequencies, reference_frequencies):
+    if candidate_frequencies is None or reference_frequencies is None:
+        return None
+    candidate = np.asarray(candidate, dtype=float)
+    reference = np.asarray(reference, dtype=float)
+    candidate = candidate.reshape(-1, candidate.shape[-1])
+    reference = reference.reshape(-1, reference.shape[-1])
+    candidate_freq = np.asarray(candidate_frequencies, dtype=float)
+    reference_freq = np.asarray(reference_frequencies, dtype=float)
+    candidate_peaks = candidate_freq[np.argmax(candidate, axis=1)]
+    reference_peaks = reference_freq[np.argmax(reference, axis=1)]
+    return float(np.mean(np.abs(candidate_peaks - reference_peaks)))
+
+
+def compare_reference_spectrum(
+    candidate,
+    reference,
+    candidate_frequencies=None,
+    reference_frequencies=None,
+    normalization="least_squares",
+    rmse_tolerance=None,
+):
+    """Compare a spectrum against an external reference spectrum.
+
+    The last axis is treated as frequency.  If both frequency grids are supplied
+    and differ, the reference is interpolated onto the candidate grid before
+    scalar metrics are computed.
+    """
+
+    candidate_arr = np.asarray(candidate, dtype=float)
+    reference_arr = np.asarray(reference, dtype=float)
+    original_reference = reference_arr
+    original_reference_frequencies = reference_frequencies
+
+    if candidate_frequencies is not None and reference_frequencies is not None:
+        candidate_freq = np.asarray(candidate_frequencies, dtype=float)
+        reference_freq = np.asarray(reference_frequencies, dtype=float)
+        if candidate_arr.shape[:-1] != reference_arr.shape[:-1]:
+            return SpectrumComparison(
+                passed=False,
+                candidate_shape=candidate_arr.shape,
+                reference_shape=reference_arr.shape,
+                normalization=str(normalization),
+                scale_factor=1.0,
+                rmse=np.nan,
+                mae=np.nan,
+                max_abs=np.nan,
+                normalized_rmse=np.nan,
+                correlation=np.nan,
+                reason="non-frequency dimensions do not match",
+            )
+        if candidate_freq.shape != reference_freq.shape or not np.allclose(candidate_freq, reference_freq):
+            reference_arr = _interpolate_last_axis(reference_arr, reference_freq, candidate_freq)
+            reference_frequencies = candidate_freq
+    elif candidate_arr.shape != reference_arr.shape:
+        return SpectrumComparison(
+            passed=False,
+            candidate_shape=candidate_arr.shape,
+            reference_shape=reference_arr.shape,
+            normalization=str(normalization),
+            scale_factor=1.0,
+            rmse=np.nan,
+            mae=np.nan,
+            max_abs=np.nan,
+            normalized_rmse=np.nan,
+            correlation=np.nan,
+            reason="shape mismatch and no frequency grids supplied for interpolation",
+        )
+
+    if candidate_arr.shape != reference_arr.shape:
+        return SpectrumComparison(
+            passed=False,
+            candidate_shape=candidate_arr.shape,
+            reference_shape=reference_arr.shape,
+            normalization=str(normalization),
+            scale_factor=1.0,
+            rmse=np.nan,
+            mae=np.nan,
+            max_abs=np.nan,
+            normalized_rmse=np.nan,
+            correlation=np.nan,
+            reason="shape mismatch after interpolation",
+        )
+
+    if not np.all(np.isfinite(candidate_arr)) or not np.all(np.isfinite(reference_arr)):
+        return SpectrumComparison(
+            passed=False,
+            candidate_shape=candidate_arr.shape,
+            reference_shape=reference_arr.shape,
+            normalization=str(normalization),
+            scale_factor=1.0,
+            rmse=np.nan,
+            mae=np.nan,
+            max_abs=np.nan,
+            normalized_rmse=np.nan,
+            correlation=np.nan,
+            reason="candidate or reference spectrum contains non-finite values",
+        )
+
+    normalization_key = str(normalization).lower()
+    if normalization_key in ("none", "raw"):
+        scale_factor = 1.0
+        candidate_scaled = candidate_arr
+        reference_scaled = reference_arr
+    elif normalization_key in ("least_squares", "least-squares", "scale"):
+        scale_factor = _least_squares_scale(candidate_arr, reference_arr)
+        candidate_scaled = scale_factor * candidate_arr
+        reference_scaled = reference_arr
+    elif normalization_key == "max":
+        candidate_max = float(np.nanmax(np.abs(candidate_arr))) if candidate_arr.size else 0.0
+        reference_max = float(np.nanmax(np.abs(reference_arr))) if reference_arr.size else 0.0
+        scale_factor = reference_max / candidate_max if candidate_max != 0.0 else 1.0
+        candidate_scaled = scale_factor * candidate_arr
+        reference_scaled = reference_arr
+    else:
+        raise ValueError("normalization must be 'none', 'max', or 'least_squares'")
+
+    delta = candidate_scaled - reference_scaled
+    rmse = float(np.sqrt(np.nanmean(delta ** 2))) if delta.size else 0.0
+    mae = float(np.nanmean(np.abs(delta))) if delta.size else 0.0
+    max_abs = float(np.nanmax(np.abs(delta))) if delta.size else 0.0
+    reference_norm = float(np.sqrt(np.nanmean(reference_scaled ** 2))) if reference_scaled.size else 0.0
+    normalized_rmse = rmse / reference_norm if reference_norm != 0.0 else rmse
+
+    cand_flat = candidate_scaled.ravel()
+    ref_flat = reference_scaled.ravel()
+    if cand_flat.size < 2 or np.std(cand_flat) == 0.0 or np.std(ref_flat) == 0.0:
+        correlation = 1.0 if np.allclose(cand_flat, ref_flat) else 0.0
+    else:
+        correlation = float(np.corrcoef(cand_flat, ref_flat)[0, 1])
+
+    peak_mae = _peak_frequency_mae(
+        candidate_scaled,
+        original_reference,
+        candidate_frequencies,
+        original_reference_frequencies,
+    )
+    passed = True if rmse_tolerance is None else normalized_rmse <= float(rmse_tolerance)
+    return SpectrumComparison(
+        passed=bool(passed),
+        candidate_shape=candidate_arr.shape,
+        reference_shape=reference_arr.shape,
+        normalization=normalization_key,
+        scale_factor=scale_factor,
+        rmse=rmse,
+        mae=mae,
+        max_abs=max_abs,
+        normalized_rmse=normalized_rmse,
+        correlation=correlation,
+        peak_frequency_mae=peak_mae,
+    )
+
+
+def run_internal_dsf_reference_validation(case=None, tolerance=1e-12):
+    """Validate pySED's direct estimator against its explicit correlation path."""
+
+    if case is None:
+        case = synthetic_dsf_validation_case()
+    direct, reference = compute_pysed_validation_pair(case)
+    coherent = compare_arrays(direct.coherent, reference.coherent, atol=tolerance, rtol=tolerance)
+    coherent_sem = compare_arrays(
+        direct.coherent_sem,
+        reference.coherent_sem,
+        atol=tolerance,
+        rtol=tolerance,
+    )
+    elastic = compare_arrays(
+        direct.elastic_coherent,
+        reference.elastic_coherent,
+        atol=tolerance,
+        rtol=tolerance,
+    )
+    return {
+        "name": "pysed_direct_vs_explicit_correlation",
+        "passed": bool(coherent["passed"] and coherent_sem["passed"] and elastic["passed"]),
+        "case": case.description,
+        "num_frames": int(case.positions.shape[0]),
+        "num_atoms": int(case.positions.shape[1]),
+        "num_qpoints": int(case.qpoints_cartesian.shape[0]),
+        "num_blocks": int(case.num_blocks),
+        "dt_seconds": float(case.dt),
+        "checks": {
+            "coherent": coherent,
+            "coherent_sem": coherent_sem,
+            "elastic_coherent": elastic,
+        },
+    }
+
+
+def package_status(module_name):
+    """Return installation metadata for an optional validation dependency."""
+
+    spec = importlib.util.find_spec(module_name)
+    if spec is None:
+        return {"module": module_name, "installed": False}
+    try:
+        module = importlib.import_module(module_name)
+        version = getattr(module, "__version__", "unknown")
+        path = getattr(module, "__file__", "unknown")
+    except Exception as exc:
+        return {
+            "module": module_name,
+            "installed": True,
+            "importable": False,
+            "error": "%s: %s" % (type(exc).__name__, exc),
+        }
+    return {
+        "module": module_name,
+        "installed": True,
+        "importable": True,
+        "version": str(version),
+        "path": str(path),
+    }
+
+
+def optional_scattering_package_report():
+    """Report optional package availability for external DSF validation."""
+
+    packages = [
+        package_status("dynasor"),
+        package_status("psf"),
+        package_status("pynamic_structure_factor"),
+        package_status("pynamic"),
+    ]
+    notes = {
+        "dynasor": (
+            "Use dynasor.compute_dynamic_structure_factors on the same trajectory "
+            "and Q points, then compare weighted Sqw on a matched frequency grid."
+        ),
+        "pynamic": (
+            "Use pynamic-structure-factor's direct selected-Q workflow with the "
+            "same Q points, weights, block/window convention, and normalization."
+        ),
+    }
+    return {"packages": packages, "notes": notes}
+
+
+def validation_environment():
+    """Return reproducibility metadata for a validation report."""
+
+    return {
+        "python": sys.version,
+        "platform": platform.platform(),
+        "numpy": np.__version__,
+        "pysed": __version__,
+    }
+
+
+def build_dsf_validation_report(case=None, tolerance=1e-12):
+    """Build a structured DSF validation report."""
+
+    if case is None:
+        case = synthetic_dsf_validation_case()
+    internal = run_internal_dsf_reference_validation(case, tolerance=tolerance)
+    external = optional_scattering_package_report()
+    return {
+        "environment": validation_environment(),
+        "internal": internal,
+        "external": external,
+        "passed": bool(internal["passed"]),
+    }
+
+
+def write_validation_report(report, path):
+    """Write a JSON validation report."""
+
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(report, handle, indent=2, sort_keys=True)
+
+
+def export_dsf_validation_case(path, case=None, include_pysed_reference=True):
+    """Export a deterministic validation case as an ``.npz`` file."""
+
+    if case is None:
+        case = synthetic_dsf_validation_case()
+    payload = {
+        "positions": case.positions,
+        "qpoints_cartesian": case.qpoints_cartesian,
+        "coherent_weights": case.coherent_weights,
+        "dt": np.asarray(case.dt),
+        "num_blocks": np.asarray(case.num_blocks),
+        "description": np.asarray(case.description),
+    }
+    if include_pysed_reference:
+        direct, reference = compute_pysed_validation_pair(case)
+        payload.update(
+            {
+                "pysed_direct_coherent": direct.coherent,
+                "pysed_reference_coherent": reference.coherent,
+                "pysed_frequencies_thz": direct.frequencies_thz,
+            }
+        )
+    np.savez(path, **payload)
+
+
+def load_dsf_validation_case(path):
+    """Load a validation case exported by :func:`export_dsf_validation_case`."""
+
+    data = np.load(path, allow_pickle=False)
+    return DSFValidationCase(
+        positions=data["positions"],
+        qpoints_cartesian=data["qpoints_cartesian"],
+        coherent_weights=data["coherent_weights"],
+        dt=float(data["dt"]),
+        num_blocks=int(data["num_blocks"]),
+        description=str(data["description"]),
+    )
+
+
+def compare_external_dsf_reference(
+    reference_path,
+    reference_key="coherent",
+    reference_frequency_key=None,
+    case=None,
+    component="coherent",
+    normalization="least_squares",
+    rmse_tolerance=None,
+):
+    """Compare pySED DSF with an external dynasor/pynamic-style ``.npz`` output."""
+
+    if case is None:
+        case = synthetic_dsf_validation_case()
+    direct, _ = compute_pysed_validation_pair(case)
+    if not hasattr(direct, component):
+        raise ValueError("candidate component %s is not available" % component)
+    candidate = getattr(direct, component)
+    candidate_frequencies = direct.frequencies_thz
+
+    data = np.load(reference_path, allow_pickle=False)
+    if reference_key not in data.files:
+        raise KeyError("reference_key %s not found in %s" % (reference_key, reference_path))
+    reference = data[reference_key]
+
+    if reference_frequency_key is None:
+        for key in ("frequencies_thz", "frequency_thz", "frequencies", "frequency", "omega"):
+            if key in data.files:
+                reference_frequency_key = key
+                break
+    elif reference_frequency_key not in data.files:
+        raise KeyError(
+            "reference_frequency_key %s not found in %s" % (reference_frequency_key, reference_path)
+        )
+    reference_frequencies = data[reference_frequency_key] if reference_frequency_key is not None else None
+
+    comparison = compare_reference_spectrum(
+        candidate,
+        reference,
+        candidate_frequencies=candidate_frequencies,
+        reference_frequencies=reference_frequencies,
+        normalization=normalization,
+        rmse_tolerance=rmse_tolerance,
+    )
+    payload = comparison.to_dict()
+    payload.update(
+        {
+            "name": "pysed_vs_external_dsf_reference",
+            "reference_path": str(reference_path),
+            "reference_key": reference_key,
+            "reference_frequency_key": reference_frequency_key,
+            "candidate_component": component,
+            "candidate_frequency_unit": "THz",
+        }
+    )
+    return payload

--- a/pySED/visibility_diagnostics.py
+++ b/pySED/visibility_diagnostics.py
@@ -1,0 +1,312 @@
+"""Mode-level visibility diagnostics for experiment-facing scattering maps."""
+
+from dataclasses import dataclass
+import csv
+
+import numpy as np
+
+
+_DIRECTION_LABELS = ("x", "y", "z")
+
+
+@dataclass
+class ModeVisibilityDiagnostics:
+    """Branch-level explanation of EELS/INS/IXS mode visibility.
+
+    The arrays have shape ``(num_q, num_g, num_modes)`` unless noted
+    otherwise.  The diagnostic quantities are derived from the complex
+    visibility decomposition
+
+    ``I = |sum_{b,alpha} A_{b,alpha}|^2``.
+    """
+
+    visibility: np.ndarray
+    relative_visibility: np.ndarray
+    atom_sum: np.ndarray
+    direction_sum: np.ndarray
+    basis_interference: np.ndarray
+    direction_interference: np.ndarray
+    basis_interference_fraction: np.ndarray
+    direction_interference_fraction: np.ndarray
+    dominant_atom_index: np.ndarray
+    dominant_direction_index: np.ndarray
+    dominant_reason: np.ndarray
+    q_error_reduced: np.ndarray
+    q_error_cartesian: np.ndarray
+    atom_labels: list
+    direction_labels: list
+    mode_labels: list
+    metadata: dict
+
+    def reason_counts(self):
+        """Return a dictionary counting the dominant reason labels."""
+
+        labels, counts = np.unique(self.dominant_reason.astype(str), return_counts=True)
+        return {str(label): int(count) for label, count in zip(labels, counts)}
+
+    def to_records(self, include_all=True, relative_threshold=None):
+        """Return a list of row dictionaries suitable for tables or CSV.
+
+        Parameters
+        ----------
+        include_all : bool
+            If ``False``, only rows with relative visibility less than
+            ``relative_threshold`` are emitted.
+        relative_threshold : float or None
+            Relative-visibility cutoff for weak-branch rows.  When ``None``,
+            the value stored in ``metadata["relative_floor"]`` is used.
+        """
+
+        cutoff = self.metadata.get("relative_floor", 1e-3)
+        if relative_threshold is not None:
+            cutoff = float(relative_threshold)
+
+        records = []
+        n_q, n_g, n_modes = self.visibility.shape
+        for i_q in range(n_q):
+            for i_g in range(n_g):
+                for i_mode in range(n_modes):
+                    rel = float(self.relative_visibility[i_q, i_g, i_mode])
+                    if not include_all and rel >= cutoff:
+                        continue
+                    atom_index = int(self.dominant_atom_index[i_q, i_g, i_mode])
+                    direction_index = int(self.dominant_direction_index[i_q, i_g, i_mode])
+                    records.append(
+                        {
+                            "q_index": i_q,
+                            "g_index": i_g,
+                            "mode_index": i_mode,
+                            "mode_label": self.mode_labels[i_mode],
+                            "visibility": float(self.visibility[i_q, i_g, i_mode]),
+                            "relative_visibility": rel,
+                            "atom_sum": float(self.atom_sum[i_q, i_g, i_mode]),
+                            "direction_sum": float(self.direction_sum[i_q, i_g, i_mode]),
+                            "basis_interference": float(self.basis_interference[i_q, i_g, i_mode]),
+                            "basis_interference_fraction": float(
+                                self.basis_interference_fraction[i_q, i_g, i_mode]
+                            ),
+                            "direction_interference": float(
+                                self.direction_interference[i_q, i_g, i_mode]
+                            ),
+                            "direction_interference_fraction": float(
+                                self.direction_interference_fraction[i_q, i_g, i_mode]
+                            ),
+                            "dominant_atom_index": atom_index,
+                            "dominant_atom_label": self.atom_labels[atom_index],
+                            "dominant_direction": self.direction_labels[direction_index],
+                            "dominant_reason": str(self.dominant_reason[i_q, i_g, i_mode]),
+                            "q_error_reduced": float(self.q_error_reduced[i_q]),
+                            "q_error_cartesian": float(self.q_error_cartesian[i_q]),
+                        }
+                    )
+        return records
+
+    def weak_records(self, relative_threshold=None):
+        """Return only branches classified as weak by relative visibility."""
+
+        return self.to_records(include_all=False, relative_threshold=relative_threshold)
+
+    def write_csv(self, path, include_all=True, relative_threshold=None):
+        """Write diagnostic records to a CSV table."""
+
+        records = self.to_records(include_all=include_all, relative_threshold=relative_threshold)
+        fieldnames = [
+            "q_index",
+            "g_index",
+            "mode_index",
+            "mode_label",
+            "visibility",
+            "relative_visibility",
+            "atom_sum",
+            "direction_sum",
+            "basis_interference",
+            "basis_interference_fraction",
+            "direction_interference",
+            "direction_interference_fraction",
+            "dominant_atom_index",
+            "dominant_atom_label",
+            "dominant_direction",
+            "dominant_reason",
+            "q_error_reduced",
+            "q_error_cartesian",
+        ]
+        with open(path, "w", newline="", encoding="utf-8") as handle:
+            writer = csv.DictWriter(handle, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(records)
+
+
+def _safe_fraction(numerator, denominator):
+    numerator = np.asarray(numerator, dtype=float)
+    denominator = np.asarray(denominator, dtype=float)
+    output = np.zeros_like(numerator, dtype=float)
+    mask = np.abs(denominator) > 0.0
+    output[mask] = numerator[mask] / denominator[mask]
+    return output
+
+
+def _relative_visibility(visibility):
+    local_max = np.max(visibility, axis=2, keepdims=True)
+    relative = np.zeros_like(visibility, dtype=float)
+    np.divide(visibility, local_max, out=relative, where=local_max > 0.0)
+    return relative
+
+
+def _labels(labels, size, prefix):
+    if labels is None:
+        return ["%s%d" % (prefix, index) for index in range(size)]
+    labels = [str(label) for label in labels]
+    if len(labels) != size:
+        raise ValueError("%s labels length must be %d" % (prefix, size))
+    return labels
+
+
+def _q_errors_from_advice(q_advice, n_q):
+    q_error_reduced = np.zeros(n_q, dtype=float)
+    q_error_cartesian = np.zeros(n_q, dtype=float)
+    if q_advice is None:
+        return q_error_reduced, q_error_cartesian
+    if hasattr(q_advice, "error_reduced") and hasattr(q_advice, "error_cartesian"):
+        reduced = np.asarray(q_advice.error_reduced, dtype=float)
+        cartesian = np.asarray(q_advice.error_cartesian, dtype=float)
+        if reduced.shape != (n_q,) or cartesian.shape != (n_q,):
+            raise ValueError("q_advice error arrays must match number of q points")
+        return reduced, cartesian
+    if len(q_advice) != n_q:
+        raise ValueError("q_advice length must match number of q points")
+    for index, advice in enumerate(q_advice):
+        q_error_reduced[index] = float(getattr(advice, "error_reduced", 0.0))
+        q_error_cartesian[index] = float(getattr(advice, "error_cartesian", 0.0))
+    return q_error_reduced, q_error_cartesian
+
+
+def _classify_reasons(
+    visibility,
+    relative_visibility,
+    atom_sum,
+    direction_sum,
+    basis_fraction,
+    direction_fraction,
+    q_error_cartesian,
+    visibility_floor,
+    relative_floor,
+    interference_floor,
+    q_error_floor,
+):
+    reasons = np.empty(visibility.shape, dtype=object)
+    n_q, n_g, n_modes = visibility.shape
+    for i_q in range(n_q):
+        q_mapped = q_error_cartesian[i_q] > q_error_floor
+        for i_g in range(n_g):
+            for i_mode in range(n_modes):
+                value = visibility[i_q, i_g, i_mode]
+                relative = relative_visibility[i_q, i_g, i_mode]
+                if value > visibility_floor and relative >= relative_floor:
+                    reasons[i_q, i_g, i_mode] = "visible"
+                    continue
+                if q_mapped:
+                    reasons[i_q, i_g, i_mode] = "finite_size_q_mapping"
+                elif atom_sum[i_q, i_g, i_mode] <= visibility_floor:
+                    reasons[i_q, i_g, i_mode] = "polarization_or_zero_weight"
+                elif basis_fraction[i_q, i_g, i_mode] <= -interference_floor:
+                    reasons[i_q, i_g, i_mode] = "basis_interference"
+                elif direction_sum[i_q, i_g, i_mode] <= visibility_floor:
+                    reasons[i_q, i_g, i_mode] = "direction_selection"
+                elif direction_fraction[i_q, i_g, i_mode] <= -interference_floor:
+                    reasons[i_q, i_g, i_mode] = "cartesian_interference"
+                else:
+                    reasons[i_q, i_g, i_mode] = "weak_visibility"
+    return reasons
+
+
+def diagnose_mode_visibility(
+    visibility_decomposition,
+    q_advice=None,
+    atom_labels=None,
+    mode_labels=None,
+    visibility_floor=1e-14,
+    relative_floor=1e-3,
+    interference_floor=0.8,
+    q_error_floor=1e-10,
+):
+    """Diagnose why each branch is visible or weak in EELS/INS/IXS.
+
+    ``visibility_decomposition`` can be an
+    :class:`pySED.eels.EELSVisibilityDecomposition` or a
+    :class:`pySED.mode_visibility.OnePhononVisibility`.  It must expose
+    ``visibility``, ``atom_visibility`` and ``direction_visibility``.  The
+    returned object quantifies atom/basis interference and Cartesian-direction
+    selection without changing the underlying scattering intensity.
+    """
+
+    required = ("visibility", "atom_visibility", "direction_visibility")
+    missing = [name for name in required if not hasattr(visibility_decomposition, name)]
+    if missing:
+        raise ValueError("visibility decomposition is missing: %s" % ", ".join(missing))
+
+    visibility = np.asarray(visibility_decomposition.visibility, dtype=float)
+    atom_visibility = np.asarray(visibility_decomposition.atom_visibility, dtype=float)
+    direction_visibility = np.asarray(visibility_decomposition.direction_visibility, dtype=float)
+    if visibility.ndim != 3:
+        raise ValueError("visibility must have shape (num_q, num_g, num_modes)")
+    if atom_visibility.shape[:3] != visibility.shape:
+        raise ValueError("atom_visibility leading dimensions must match visibility")
+    if direction_visibility.shape != visibility.shape + (3,):
+        raise ValueError("direction_visibility must have shape (num_q, num_g, num_modes, 3)")
+
+    atom_sum = np.sum(atom_visibility, axis=3)
+    direction_sum = np.sum(direction_visibility, axis=3)
+    basis_interference = visibility - atom_sum
+    direction_interference = visibility - direction_sum
+    basis_fraction = _safe_fraction(basis_interference, atom_sum)
+    direction_fraction = _safe_fraction(direction_interference, direction_sum)
+    relative = _relative_visibility(visibility)
+    dominant_atom = np.argmax(atom_visibility, axis=3)
+    dominant_direction = np.argmax(direction_visibility, axis=3)
+    q_error_reduced, q_error_cartesian = _q_errors_from_advice(q_advice, visibility.shape[0])
+
+    reasons = _classify_reasons(
+        visibility,
+        relative,
+        atom_sum,
+        direction_sum,
+        basis_fraction,
+        direction_fraction,
+        q_error_cartesian,
+        float(visibility_floor),
+        float(relative_floor),
+        float(interference_floor),
+        float(q_error_floor),
+    )
+
+    n_modes = visibility.shape[2]
+    n_atoms = atom_visibility.shape[3]
+    metadata = {
+        "source_model": getattr(visibility_decomposition, "metadata", {}).get("model"),
+        "visibility_floor": float(visibility_floor),
+        "relative_floor": float(relative_floor),
+        "interference_floor": float(interference_floor),
+        "q_error_floor": float(q_error_floor),
+        "basis_interference": "I_total - sum_b |sum_alpha A_balpha|^2",
+        "direction_interference": "I_total - sum_alpha |sum_b A_balpha|^2",
+    }
+
+    return ModeVisibilityDiagnostics(
+        visibility=visibility,
+        relative_visibility=relative,
+        atom_sum=atom_sum,
+        direction_sum=direction_sum,
+        basis_interference=basis_interference,
+        direction_interference=direction_interference,
+        basis_interference_fraction=basis_fraction,
+        direction_interference_fraction=direction_fraction,
+        dominant_atom_index=dominant_atom,
+        dominant_direction_index=dominant_direction,
+        dominant_reason=reasons,
+        q_error_reduced=q_error_reduced,
+        q_error_cartesian=q_error_cartesian,
+        atom_labels=_labels(atom_labels, n_atoms, "atom"),
+        direction_labels=list(_DIRECTION_LABELS),
+        mode_labels=_labels(mode_labels, n_modes, "mode"),
+        metadata=metadata,
+    )

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,10 @@ setup(
         "scipy",
         "psutil",
     ],
+    extras_require={
+        "gpu-cuda11x": ["cupy-cuda11x"],
+        "gpu-cuda12x": ["cupy-cuda12x"],
+    },
     license='MIT License',
     entry_points={
         'console_scripts': [

--- a/tests/test_compare_experiment.py
+++ b/tests/test_compare_experiment.py
@@ -1,0 +1,261 @@
+import numpy as np
+
+from pySED.compare_experiment import (
+    ScatteringMap,
+    align_intensity_map,
+    apply_quantum_correction_to_map,
+    compare_maps,
+    comparison_linecut_records,
+    comparison_peak_records,
+    comparison_residual_map,
+    comparison_summary,
+    convolve_resolution_units,
+    crop_image,
+    image_to_grayscale,
+    load_scattering_map_image,
+    normalize_intensity,
+    prepare_map_comparison,
+    scattering_map_from_image,
+    track_peak_positions,
+    write_map_comparison_report,
+)
+
+
+def test_compare_maps_identical_after_normalization():
+    arr = np.array([[0.0, 1.0], [2.0, 3.0]])
+    comparison = compare_maps(arr, arr * 2.0, normalization="max")
+
+    assert comparison.rmse == 0.0
+    assert comparison.mae == 0.0
+    assert comparison.correlation > 0.999
+
+
+def test_peak_tracking_returns_energy_values():
+    energy = np.array([0.0, 1.0, 2.0])
+    intensity = np.array([[0.0, 5.0, 1.0], [2.0, 1.0, 0.0]])
+    np.testing.assert_allclose(track_peak_positions(intensity, energy), [1.0, 0.0])
+
+
+def test_normalize_area():
+    arr = np.array([1.0, 1.0, 2.0])
+    np.testing.assert_allclose(normalize_intensity(arr, "area"), arr / 4.0)
+
+
+def test_image_to_grayscale_and_crop():
+    image = np.zeros((3, 4, 3), dtype=float)
+    image[:, :, 0] = 1.0
+    gray = image_to_grayscale(image)
+    cropped = crop_image(gray, crop=(1, 3, 1, 4))
+
+    np.testing.assert_allclose(gray, 0.299)
+    assert cropped.shape == (2, 3)
+
+
+def test_scattering_map_from_image_calibrates_axes_origin_and_inversion():
+    image = np.array(
+        [
+            [0.0, 0.25, 0.50],
+            [0.50, 0.75, 1.00],
+        ]
+    )
+
+    scattering_map = scattering_map_from_image(
+        image,
+        q_range=(0.0, 2.0),
+        energy_range=(10.0, 20.0),
+        invert=True,
+        origin="upper",
+    )
+
+    np.testing.assert_allclose(scattering_map.q_axis, [0.0, 1.0, 2.0])
+    np.testing.assert_allclose(scattering_map.energy_axis, [10.0, 20.0])
+    expected_after_invert_and_flip = np.array(
+        [
+            [0.50, 0.25, 0.00],
+            [1.00, 0.75, 0.50],
+        ]
+    )
+    np.testing.assert_allclose(scattering_map.intensity, expected_after_invert_and_flip.T)
+    assert scattering_map.metadata["inverted"] is True
+
+
+def test_load_scattering_map_image_from_png(tmp_path):
+    import matplotlib
+
+    matplotlib.use("Agg")
+    from matplotlib import pyplot as plt
+
+    image = np.array([[0.0, 0.5], [0.75, 1.0]])
+    path = tmp_path / "experimental.png"
+    plt.imsave(path, image, cmap="gray", vmin=0.0, vmax=1.0)
+
+    scattering_map = load_scattering_map_image(
+        path,
+        q_range=(-0.1, 0.1),
+        energy_range=(0.0, 50.0),
+        normalization="max",
+    )
+
+    assert scattering_map.intensity.shape == (2, 2)
+    np.testing.assert_allclose(scattering_map.q_axis, [-0.1, 0.1])
+    np.testing.assert_allclose(scattering_map.energy_axis, [0.0, 50.0])
+    assert scattering_map.metadata["image_path"].endswith("experimental.png")
+    assert np.nanmax(scattering_map.intensity) == 1.0
+
+
+def test_align_intensity_map_interpolates_q_and_energy_axes():
+    source_q = np.array([0.0, 1.0])
+    source_energy = np.array([0.0, 2.0])
+    intensity = np.array([[0.0, 2.0], [10.0, 12.0]])
+
+    aligned = align_intensity_map(
+        intensity,
+        source_q,
+        source_energy,
+        target_q=np.array([0.5]),
+        target_energy=np.array([1.0]),
+    )
+
+    np.testing.assert_allclose(aligned, [[6.0]])
+
+
+def test_resolution_convolution_uses_axis_units():
+    scattering_map = ScatteringMap(
+        q_axis=np.array([0.0, 0.5, 1.0]),
+        energy_axis=np.array([0.0, 2.0, 4.0]),
+        intensity=np.eye(3),
+    )
+
+    broadened = convolve_resolution_units(scattering_map, sigma_q=0.5, sigma_energy=2.0)
+
+    assert broadened.intensity.shape == scattering_map.intensity.shape
+    assert broadened.metadata["sigma_q_points"] == 1.0
+    assert broadened.metadata["sigma_energy_points"] == 1.0
+    assert broadened.intensity[0, 1] > 0
+
+
+def test_prepare_map_comparison_aligns_broadens_and_compares():
+    simulated = ScatteringMap(
+        q_axis=np.array([0.0, 1.0]),
+        energy_axis=np.array([0.0, 2.0]),
+        intensity=np.array([[0.0, 2.0], [10.0, 12.0]]),
+    )
+    experimental = ScatteringMap(
+        q_axis=np.array([0.5]),
+        energy_axis=np.array([1.0]),
+        intensity=np.array([[6.0]]),
+    )
+
+    comparison = prepare_map_comparison(
+        simulated,
+        experimental,
+        sigma_q=0.0,
+        sigma_energy=0.0,
+        normalization="none",
+    )
+
+    np.testing.assert_allclose(comparison.simulated, [[6.0]])
+    np.testing.assert_allclose(comparison.residual, [[0.0]])
+    assert comparison.rmse == 0.0
+    assert comparison.simulated_map.q_axis[0] == 0.5
+
+
+def test_apply_quantum_correction_to_map_updates_intensity_and_metadata():
+    scattering_map = ScatteringMap(
+        q_axis=np.array([0.0]),
+        energy_axis=np.array([0.0, 10.0]),
+        intensity=np.ones((1, 2)),
+    )
+
+    corrected = apply_quantum_correction_to_map(scattering_map, temperature=300.0, energy_unit="meV")
+
+    assert corrected.intensity[0, 0] == 1.0
+    assert corrected.intensity[0, 1] > 1.0
+    assert corrected.metadata["quantum_temperature_kelvin"] == 300.0
+
+
+def test_prepare_map_comparison_can_apply_quantum_correction():
+    simulated = ScatteringMap(
+        q_axis=np.array([0.0]),
+        energy_axis=np.array([0.0, 10.0]),
+        intensity=np.ones((1, 2)),
+    )
+    experimental = ScatteringMap(
+        q_axis=np.array([0.0]),
+        energy_axis=np.array([0.0, 10.0]),
+        intensity=np.ones((1, 2)),
+    )
+
+    comparison = prepare_map_comparison(
+        simulated,
+        experimental,
+        normalization="none",
+        quantum_temperature=300.0,
+        energy_unit="meV",
+    )
+
+    assert comparison.simulated[0, 1] > comparison.experimental[0, 1]
+    assert comparison.simulated_map.metadata["quantum_correction"].startswith("harmonic")
+
+
+def test_comparison_report_exports_summary_residual_and_peaks(tmp_path):
+    simulated = ScatteringMap(
+        q_axis=np.array([0.0, 1.0]),
+        energy_axis=np.array([0.0, 5.0, 10.0]),
+        intensity=np.array([[0.0, 2.0, 1.0], [0.0, 1.0, 3.0]]),
+        metadata={"numpy_value": np.float64(2.0), "array_value": np.array([1, 2])},
+    )
+    experimental = ScatteringMap(
+        q_axis=np.array([0.0, 1.0]),
+        energy_axis=np.array([0.0, 5.0, 10.0]),
+        intensity=np.array([[0.0, 1.0, 2.0], [0.0, 1.0, 3.0]]),
+    )
+    comparison = prepare_map_comparison(
+        simulated,
+        experimental,
+        sigma_q=0.0,
+        sigma_energy=0.0,
+        normalization="none",
+    )
+
+    summary = comparison_summary(comparison)
+    residual_map = comparison_residual_map(comparison)
+    peaks = comparison_peak_records(comparison)
+    linecuts = comparison_linecut_records(comparison, q_indices=[0], energy_indices=[2])
+    written = write_map_comparison_report(
+        comparison,
+        tmp_path,
+        prefix="eels",
+        linecut_q_indices=[0],
+        linecut_energy_indices=[2],
+    )
+
+    assert summary["simulated_shape"] == [2, 3]
+    assert summary["residual_max_abs"] == 1.0
+    assert residual_map.metadata["definition"].startswith("normalized simulated")
+    assert peaks[0]["simulated_peak_energy"] == 5.0
+    assert peaks[0]["experimental_peak_energy"] == 10.0
+    assert len(linecuts) == 5
+    assert linecuts[0]["cut_axis"] == "energy_at_q"
+    assert linecuts[-1]["cut_axis"] == "q_at_energy"
+    assert set(written) == {"summary", "residual", "peaks", "linecuts"}
+
+    import csv
+    import json
+
+    with open(written["summary"], "r", encoding="utf-8") as handle:
+        loaded_summary = json.load(handle)
+    with open(written["peaks"], "r", encoding="utf-8") as handle:
+        peak_rows = list(csv.DictReader(handle))
+    with open(written["residual"], "r", encoding="utf-8") as handle:
+        residual_rows = list(csv.DictReader(handle))
+    with open(written["linecuts"], "r", encoding="utf-8") as handle:
+        linecut_rows = list(csv.DictReader(handle))
+
+    assert loaded_summary["rmse"] == summary["rmse"]
+    assert loaded_summary["simulated_metadata"]["numpy_value"] == 2.0
+    assert loaded_summary["simulated_metadata"]["array_value"] == [1, 2]
+    assert peak_rows[0]["peak_energy_delta"] == "-5.0"
+    assert len(residual_rows) == 6
+    assert len(linecut_rows) == 5
+    assert linecut_rows[0]["energy_value"] == "0.0"

--- a/tests/test_dsf.py
+++ b/tests/test_dsf.py
@@ -1,0 +1,253 @@
+import numpy as np
+from scipy.fft import fft
+
+from pySED.dsf import (
+    compute_coherent_dsf_via_correlation,
+    compute_current_correlations,
+    compute_dsf,
+    compute_partial_dsf,
+    xray_form_factor_weights,
+)
+
+
+def test_dsf_shapes_and_nonnegative_intensity():
+    n_frames = 32
+    dt = 1e-12
+    positions = np.zeros((n_frames, 2, 3))
+    positions[:, 1, 0] = 0.5
+    qpoints = np.array([[2 * np.pi, 0.0, 0.0], [0.0, 2 * np.pi, 0.0]])
+
+    result = compute_dsf(
+        positions,
+        qpoints,
+        dt,
+        atom_types=["Si", "Si"],
+        experiment="neutron",
+        num_blocks=2,
+    )
+
+    assert result.coherent.shape == (2, 8)
+    assert result.incoherent.shape == (2, 8)
+    assert result.total.shape == (2, 8)
+    assert np.all(result.total >= 0)
+    assert np.all(result.elastic_coherent >= 0)
+
+
+def test_current_correlations_shapes():
+    n_frames = 32
+    dt = 1e-12
+    positions = np.zeros((n_frames, 1, 3))
+    velocities = np.zeros_like(positions)
+    velocities[:, 0, 0] = 1.0
+    qpoints = np.array([[2 * np.pi, 0.0, 0.0]])
+
+    result = compute_current_correlations(positions, velocities, qpoints, dt)
+
+    assert result.longitudinal.shape == (1, 16)
+    assert result.transverse.shape == (1, 16)
+    assert result.longitudinal_sem.shape == result.longitudinal.shape
+    assert result.transverse_sem.shape == result.transverse.shape
+    assert result.metadata["uncertainty"] == "standard error of the block-averaged spectra"
+    assert result.longitudinal[0, 0] > 0
+
+
+def test_dsf_matches_direct_density_fft_estimator():
+    n_frames = 16
+    n_atoms = 3
+    dt = 2e-13
+    time = np.arange(n_frames, dtype=float)
+    positions = np.zeros((n_frames, n_atoms, 3), dtype=float)
+    positions[:, 0, 0] = 0.05 * np.sin(2 * np.pi * time / n_frames)
+    positions[:, 1, 1] = 0.10 * np.cos(4 * np.pi * time / n_frames)
+    positions[:, 2, 2] = 0.15 * np.sin(6 * np.pi * time / n_frames)
+
+    qpoints = np.array(
+        [
+            [2 * np.pi, 0.0, 0.0],
+            [0.0, 2 * np.pi, 0.0],
+        ]
+    )
+    weights = np.array(
+        [
+            [1.0, 2.0, 3.0],
+            [0.5, 1.5, 2.5],
+        ]
+    )
+
+    result = compute_dsf(
+        positions,
+        qpoints,
+        dt,
+        experiment="custom",
+        coherent_weights=weights,
+        num_blocks=1,
+    )
+
+    expected = []
+    for q_index, q_vec in enumerate(qpoints):
+        phase = np.exp(1j * np.tensordot(positions, q_vec, axes=([2], [0])))
+        rho = phase @ weights[q_index]
+        spectrum = np.abs(fft(rho, norm="forward")) ** 2
+        expected.append(spectrum[: n_frames // 2].real / (n_frames * n_atoms))
+
+    np.testing.assert_allclose(result.coherent, np.asarray(expected), rtol=1e-14, atol=1e-14)
+
+
+def test_dsf_cpu_backend_matches_default_backend():
+    positions = np.zeros((16, 2, 3), dtype=float)
+    positions[:, 1, 0] = np.linspace(0.0, 0.5, 16)
+    qpoints = np.array([[2 * np.pi, 0.0, 0.0]])
+    weights = np.array([1.0, 2.0])
+
+    default = compute_dsf(
+        positions,
+        qpoints,
+        dt=1e-12,
+        experiment="custom",
+        coherent_weights=weights,
+        num_blocks=2,
+    )
+    cpu = compute_dsf(
+        positions,
+        qpoints,
+        dt=1e-12,
+        experiment="custom",
+        coherent_weights=weights,
+        num_blocks=2,
+        backend="cpu",
+    )
+
+    np.testing.assert_allclose(cpu.coherent, default.coherent)
+    np.testing.assert_allclose(cpu.coherent_sem, default.coherent_sem)
+    assert cpu.metadata["backend"] == "cpu"
+
+
+def test_xray_dsf_uses_q_dependent_form_factors_by_default():
+    n_frames = 16
+    positions = np.zeros((n_frames, 1, 3), dtype=float)
+    qpoints = np.array([[0.0, 0.0, 0.0], [8.0, 0.0, 0.0]])
+
+    result = compute_dsf(
+        positions,
+        qpoints,
+        dt=1e-12,
+        atom_types=["C"],
+        experiment="xray",
+    )
+    weights = xray_form_factor_weights(["C"], qpoints)
+    expected_ratio = (weights[1, 0] / weights[0, 0]) ** 2
+
+    assert result.coherent[1, 0] < result.coherent[0, 0]
+    np.testing.assert_allclose(
+        result.coherent[1, 0] / result.coherent[0, 0],
+        expected_ratio,
+        rtol=1e-14,
+    )
+    assert result.metadata["xray_weights"] == "Cromer-Mann form factors with atomic-number fallback"
+
+
+def test_dsf_reports_block_standard_error():
+    block_size = 8
+    n_frames = 2 * block_size
+    positions = np.zeros((n_frames, 1, 3), dtype=float)
+    positions[block_size:, 0, 0] = np.arange(block_size, dtype=float) / block_size
+
+    result = compute_dsf(
+        positions,
+        np.array([[2 * np.pi, 0.0, 0.0]]),
+        dt=1e-12,
+        experiment="custom",
+        num_blocks=2,
+    )
+
+    assert result.coherent_sem.shape == result.coherent.shape
+    assert result.incoherent_sem.shape == result.incoherent.shape
+    assert result.total_sem.shape == result.total.shape
+    assert result.elastic_coherent_sem.shape == result.elastic_coherent.shape
+    assert result.coherent_sem[0, 0] > 0
+    assert result.coherent_sem[0, 1] > 0
+    np.testing.assert_allclose(result.total_sem, result.coherent_sem)
+
+
+def test_direct_dsf_matches_correlation_function_reference():
+    n_frames = 24
+    n_atoms = 2
+    dt = 5e-13
+    time = np.arange(n_frames, dtype=float)
+    positions = np.zeros((n_frames, n_atoms, 3), dtype=float)
+    positions[:, 0, 0] = 0.08 * np.sin(2 * np.pi * time / 12)
+    positions[:, 0, 1] = 0.03 * np.cos(2 * np.pi * time / 8)
+    positions[:, 1, 0] = 0.25 + 0.05 * np.cos(2 * np.pi * time / 6)
+    positions[:, 1, 2] = 0.04 * np.sin(2 * np.pi * time / 4)
+    qpoints = np.array([[2 * np.pi, 0.0, 0.0], [0.0, 2 * np.pi, 2 * np.pi]])
+    weights = np.array([[1.0, 2.0], [0.75, 1.25]])
+
+    direct = compute_dsf(
+        positions,
+        qpoints,
+        dt,
+        experiment="custom",
+        coherent_weights=weights,
+        num_blocks=3,
+    )
+    reference = compute_coherent_dsf_via_correlation(
+        positions,
+        qpoints,
+        dt,
+        coherent_weights=weights,
+        num_blocks=3,
+    )
+
+    np.testing.assert_allclose(direct.coherent, reference.coherent, rtol=1e-13, atol=1e-15)
+    np.testing.assert_allclose(direct.coherent_sem, reference.coherent_sem, rtol=1e-13, atol=1e-15)
+    np.testing.assert_allclose(direct.elastic_coherent, reference.elastic_coherent)
+
+
+def test_partial_dsf_reconstructs_weighted_coherent_total():
+    n_frames = 24
+    dt = 1e-12
+    time = np.arange(n_frames, dtype=float)
+    positions = np.zeros((n_frames, 4, 3), dtype=float)
+    positions[:, 0, 0] = 0.03 * np.sin(2 * np.pi * time / 12)
+    positions[:, 1, 0] = 0.50 + 0.04 * np.cos(2 * np.pi * time / 8)
+    positions[:, 2, 1] = 0.25 + 0.02 * np.sin(2 * np.pi * time / 6)
+    positions[:, 3, 2] = 0.75 + 0.05 * np.cos(2 * np.pi * time / 4)
+    atom_types = np.array(["Si", "Si", "O", "O"])
+    qpoints = np.array([[2 * np.pi, 0.0, 0.0], [0.0, 2 * np.pi, 2 * np.pi]])
+    species_weights = {"Si": 2.0, "O": 0.5}
+    atom_weights = np.array([species_weights[str(atom)] for atom in atom_types])
+
+    total = compute_dsf(
+        positions,
+        qpoints,
+        dt,
+        experiment="custom",
+        coherent_weights=atom_weights,
+        num_blocks=3,
+    )
+    partial = compute_partial_dsf(
+        positions,
+        qpoints,
+        dt,
+        atom_types=atom_types,
+        species_weights=species_weights,
+        num_blocks=3,
+    )
+
+    assert partial.species == ("Si", "O")
+    assert partial.partial.shape == (2, 2, 2, 4)
+    np.testing.assert_allclose(partial.weighted_total, total.coherent, rtol=1e-13, atol=1e-15)
+    np.testing.assert_allclose(partial.weighted_total_sem, total.coherent_sem, rtol=1e-13, atol=1e-15)
+
+
+def test_partial_dsf_cross_terms_are_hermitian():
+    positions = np.zeros((8, 2, 3), dtype=float)
+    positions[:, 1, 0] = np.linspace(0.0, 0.5, 8)
+    result = compute_partial_dsf(
+        positions,
+        np.array([[2 * np.pi, 0.0, 0.0]]),
+        dt=1e-12,
+        atom_types=["A", "B"],
+    )
+
+    np.testing.assert_allclose(result.partial[0, 0, 1], np.conjugate(result.partial[0, 1, 0]))

--- a/tests/test_eels.py
+++ b/tests/test_eels.py
@@ -1,0 +1,253 @@
+import numpy as np
+import pytest
+
+from pySED.eels import (
+    build_eels_decomposition_map_from_mode_spectra,
+    build_eels_map,
+    build_eels_map_from_mode_spectra,
+    compute_mode_visibility,
+    compute_mode_visibility_decomposition,
+    compute_mode_visibility_for_q_path,
+)
+from pySED.probe_weights import electron_form_factor_weights
+
+
+def test_extended_zone_interference_selects_different_modes():
+    primitive = np.eye(3)
+    basis_positions = np.array([[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]])
+    masses = np.ones(2)
+    qpoints = np.array([[0.0, 0.0, 0.0]])
+    g_vectors = np.array([[1.0, 0.0, 0.0], [2.0, 0.0, 0.0]])
+
+    eig = np.zeros((1, 2, 2, 3), dtype=complex)
+    eig[0, 0, :, 0] = [1.0, 1.0] / np.sqrt(2.0)   # acoustic-like
+    eig[0, 1, :, 0] = [1.0, -1.0] / np.sqrt(2.0)  # optic-like
+
+    result = compute_mode_visibility(qpoints, g_vectors, primitive, basis_positions, masses, eig)
+
+    acoustic_g1, optic_g1 = result.visibility[0, 0]
+    acoustic_g2, optic_g2 = result.visibility[0, 1]
+    assert optic_g1 > acoustic_g1
+    assert acoustic_g2 > optic_g2
+
+
+def test_visibility_decomposition_reports_atom_interference_and_direction_selection():
+    primitive = np.eye(3)
+    basis_positions = np.array([[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]])
+    masses = np.ones(2)
+    qpoints = np.array([[0.0, 0.0, 0.0]])
+    g_vectors = np.array([[1.0, 0.0, 0.0]])
+
+    eig = np.zeros((1, 2, 2, 3), dtype=complex)
+    eig[0, 0, :, 0] = [1.0, 1.0] / np.sqrt(2.0)
+    eig[0, 1, :, 0] = [1.0, -1.0] / np.sqrt(2.0)
+
+    result = compute_mode_visibility_decomposition(
+        qpoints,
+        g_vectors,
+        primitive,
+        basis_positions,
+        masses,
+        eig,
+    )
+
+    assert result.atom_interference[0, 0, 0] < 0.0
+    assert result.atom_interference[0, 0, 1] > 0.0
+    np.testing.assert_allclose(result.direction_visibility[0, 0, :, 1:], 0.0, atol=1e-14)
+    np.testing.assert_allclose(np.abs(result.amplitude) ** 2, result.visibility)
+
+
+def test_eels_decomposition_map_preserves_atom_interference_identity():
+    primitive = np.eye(3)
+    basis_positions = np.array([[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]])
+    masses = np.ones(2)
+    qpoints = np.array([[0.0, 0.0, 0.0]])
+    g_vectors = np.array([[1.0, 0.0, 0.0]])
+
+    eig = np.zeros((1, 2, 2, 3), dtype=complex)
+    eig[0, 0, :, 0] = [1.0, 1.0] / np.sqrt(2.0)
+    eig[0, 1, :, 0] = [1.0, -1.0] / np.sqrt(2.0)
+
+    decomposition = compute_mode_visibility_decomposition(
+        qpoints,
+        g_vectors,
+        primitive,
+        basis_positions,
+        masses,
+        eig,
+    )
+    energy = np.array([1.0, 2.0, 3.0])
+    mode_spectra = np.zeros((3, 1, 2), dtype=float)
+    mode_spectra[:, 0, 0] = [1.0, 2.0, 3.0]
+    mode_spectra[:, 0, 1] = [4.0, 5.0, 6.0]
+
+    diagnostic = build_eels_decomposition_map_from_mode_spectra(
+        decomposition,
+        mode_spectra,
+        energy,
+    )
+
+    assert diagnostic.atom_intensity.shape == (1, 1, 2, 3)
+    assert diagnostic.direction_intensity.shape == (1, 1, 3, 3)
+    np.testing.assert_allclose(
+        diagnostic.intensity,
+        np.sum(diagnostic.atom_intensity, axis=2) + diagnostic.atom_interference_intensity,
+    )
+
+
+def test_build_eels_map_from_visibility():
+    primitive = np.eye(3)
+    basis_positions = np.array([[0.0, 0.0, 0.0]])
+    masses = np.ones(1)
+    qpoints = np.array([[0.0, 0.0, 0.0]])
+    g_vectors = np.array([[1.0, 0.0, 0.0]])
+    eig = np.zeros((1, 1, 1, 3), dtype=complex)
+    eig[0, 0, 0, 0] = 1.0
+
+    visibility = compute_mode_visibility(qpoints, g_vectors, primitive, basis_positions, masses, eig)
+    energy = np.linspace(0, 10, 101)
+    eels_map = build_eels_map(visibility, np.array([[5.0]]), energy, broadening=0.2)
+
+    assert eels_map.intensity.shape == (1, 1, 101)
+    assert energy[np.argmax(eels_map.intensity[0, 0])] == 5.0
+
+
+def test_build_eels_map_from_branch_resolved_mode_spectra():
+    primitive = np.eye(3)
+    basis_positions = np.array([[0.0, 0.0, 0.0]])
+    masses = np.ones(1)
+    qpoints = np.array([[0.0, 0.0, 0.0], [0.25, 0.0, 0.0]])
+    g_vectors = np.array([[1.0, 0.0, 0.0], [2.0, 0.0, 0.0]])
+    eig = np.zeros((2, 2, 1, 3), dtype=complex)
+    eig[:, 0, 0, 0] = 1.0
+    eig[:, 1, 0, 1] = 1.0
+
+    visibility = compute_mode_visibility(qpoints, g_vectors, primitive, basis_positions, masses, eig)
+    energy = np.array([1.0, 2.0, 3.0])
+    mode_spectra = np.zeros((3, 2, 2), dtype=float)
+    mode_spectra[:, 0, 0] = [1.0, 2.0, 3.0]
+    mode_spectra[:, 0, 1] = [4.0, 5.0, 6.0]
+    mode_spectra[:, 1, 0] = [7.0, 8.0, 9.0]
+    mode_spectra[:, 1, 1] = [10.0, 11.0, 12.0]
+
+    eels_map = build_eels_map_from_mode_spectra(visibility, mode_spectra, energy)
+    expected = np.einsum("qgm,eqm->qge", visibility.visibility, mode_spectra)
+
+    assert eels_map.intensity.shape == (2, 2, 3)
+    np.testing.assert_allclose(eels_map.intensity, expected)
+
+
+def test_pairwise_eels_q_path_does_not_form_q_by_g_cartesian_product():
+    primitive = np.eye(3)
+    basis_positions = np.array([[0.0, 0.0, 0.0]])
+    masses = np.ones(1)
+    qpoints = np.array([[0.0, 0.0, 0.0], [0.25, 0.0, 0.0]])
+    g_vectors = np.array([[1.0, 0.0, 0.0], [2.0, 0.0, 0.0]])
+    eig = np.zeros((2, 1, 1, 3), dtype=complex)
+    eig[:, 0, 0, 0] = 1.0
+
+    product = compute_mode_visibility(qpoints, g_vectors, primitive, basis_positions, masses, eig)
+    path = compute_mode_visibility_for_q_path(
+        qpoints,
+        g_vectors,
+        primitive,
+        basis_positions,
+        masses,
+        eig,
+    )
+
+    assert product.visibility.shape == (2, 2, 1)
+    assert path.visibility.shape == (2, 1, 1)
+    np.testing.assert_allclose(path.Q_reduced[:, 0, :], qpoints + g_vectors)
+    assert path.metadata["pairwise_g_vectors"] is True
+
+
+def test_pairwise_eels_q_path_validates_shape():
+    with pytest.raises(ValueError, match="pairwise"):
+        compute_mode_visibility_for_q_path(
+            np.array([[0.0, 0.0, 0.0], [0.25, 0.0, 0.0]]),
+            np.array([[1.0, 0.0, 0.0]]),
+            np.eye(3),
+            np.array([[0.0, 0.0, 0.0]]),
+            np.ones(1),
+            np.ones((2, 1, 1, 3), dtype=complex),
+        )
+
+
+def test_mott_bethe_electron_form_factor_weights_eels_visibility():
+    primitive = np.eye(3)
+    basis_positions = np.array([[0.0, 0.0, 0.0]])
+    masses = np.ones(1)
+    qpoints = np.array([[0.5, 0.0, 0.0]])
+    g_vectors = np.array([[0.0, 0.0, 0.0]])
+    eig = np.zeros((1, 1, 1, 3), dtype=complex)
+    eig[0, 0, 0, 0] = 1.0
+
+    unit = compute_mode_visibility(qpoints, g_vectors, primitive, basis_positions, masses, eig)
+    mott_bethe = compute_mode_visibility(
+        qpoints,
+        g_vectors,
+        primitive,
+        basis_positions,
+        masses,
+        eig,
+        atom_types=["C"],
+        electron_form_factor_model="mott-bethe",
+    )
+    expected_weight = electron_form_factor_weights(["C"], mott_bethe.Q_cartesian.reshape(-1, 3))[0, 0]
+
+    np.testing.assert_allclose(mott_bethe.visibility, unit.visibility * expected_weight ** 2)
+    assert mott_bethe.metadata["electron_form_factor_model"] == "mott-bethe"
+
+
+def test_mott_bethe_eels_visibility_requires_atom_types():
+    with pytest.raises(ValueError, match="atom_types"):
+        compute_mode_visibility(
+            np.array([[0.5, 0.0, 0.0]]),
+            np.array([[0.0, 0.0, 0.0]]),
+            np.eye(3),
+            np.array([[0.0, 0.0, 0.0]]),
+            np.ones(1),
+            np.ones((1, 1, 1, 3), dtype=complex),
+            electron_form_factor_model="mott-bethe",
+        )
+
+
+def test_explicit_electron_form_factors_override_model():
+    primitive = np.eye(3)
+    basis_positions = np.array([[0.0, 0.0, 0.0]])
+    masses = np.ones(1)
+    qpoints = np.array([[0.5, 0.0, 0.0]])
+    g_vectors = np.array([[0.0, 0.0, 0.0]])
+    eig = np.zeros((1, 1, 1, 3), dtype=complex)
+    eig[0, 0, 0, 0] = 1.0
+
+    result = compute_mode_visibility(
+        qpoints,
+        g_vectors,
+        primitive,
+        basis_positions,
+        masses,
+        eig,
+        electron_form_factors=np.array([2.0]),
+        atom_types=["C"],
+        electron_form_factor_model="mott-bethe",
+    )
+    unit = compute_mode_visibility(qpoints, g_vectors, primitive, basis_positions, masses, eig)
+
+    np.testing.assert_allclose(result.visibility, unit.visibility * 4.0)
+    assert result.metadata["electron_form_factor_model"] == "user supplied"
+
+
+def test_build_eels_map_from_mode_spectra_validates_shape():
+    visibility = compute_mode_visibility(
+        np.array([[0.0, 0.0, 0.0]]),
+        np.array([[1.0, 0.0, 0.0]]),
+        np.eye(3),
+        np.array([[0.0, 0.0, 0.0]]),
+        np.ones(1),
+        np.ones((1, 1, 1, 3), dtype=complex),
+    )
+
+    with pytest.raises(ValueError, match="mode_spectra"):
+        build_eels_map_from_mode_spectra(visibility, np.ones((1, 1)), np.ones(1))

--- a/tests/test_eigen_sed.py
+++ b/tests/test_eigen_sed.py
@@ -1,0 +1,87 @@
+import numpy as np
+
+from pySED.eigen_sed import EigenvectorSet, compute_eigen_sed
+
+
+def _single_mode_inputs():
+    n_frames = 64
+    dt = 1e-12
+    target_bin = 5
+    time = np.arange(n_frames) * dt
+    freq_hz = target_bin / (n_frames * dt)
+
+    velocities = np.zeros((n_frames, 1, 3))
+    velocities[:, 0, 0] = np.cos(2 * np.pi * freq_hz * time)
+    unitcell_vectors = np.zeros((1, 3))
+    basis_index = np.array([1])
+    masses = np.array([1.0])
+    primitive = np.eye(3)
+    supercell = np.eye(3)
+
+    eig = np.zeros((1, 1, 1, 3), dtype=complex)
+    eig[0, 0, 0, 0] = 1.0
+    eigset = EigenvectorSet(
+        qpoints_reduced=np.array([[0.0, 0.0, 0.0]]),
+        frequencies=np.array([[freq_hz / 1e12]]),
+        eigenvectors=eig,
+    )
+
+    return {
+        "velocities": velocities,
+        "unitcell_vectors": unitcell_vectors,
+        "basis_index": basis_index,
+        "masses": masses,
+        "primitive_cell": primitive,
+        "supercell_cell": supercell,
+        "eigenvectors": eigset,
+        "dt": dt,
+        "target_bin": target_bin,
+    }
+
+
+def test_eigen_sed_peak_frequency_for_single_mode():
+    inputs = _single_mode_inputs()
+    result = compute_eigen_sed(
+        inputs["velocities"],
+        inputs["unitcell_vectors"],
+        inputs["basis_index"],
+        inputs["masses"],
+        inputs["primitive_cell"],
+        inputs["supercell_cell"],
+        inputs["eigenvectors"],
+        inputs["dt"],
+    )
+
+    peak = int(np.argmax(result.sed[:, 0, 0]))
+    assert peak == inputs["target_bin"]
+    assert result.metadata["backend"] == "cpu"
+
+
+def test_eigen_sed_cpu_backend_matches_default():
+    inputs = _single_mode_inputs()
+
+    default = compute_eigen_sed(
+        inputs["velocities"],
+        inputs["unitcell_vectors"],
+        inputs["basis_index"],
+        inputs["masses"],
+        inputs["primitive_cell"],
+        inputs["supercell_cell"],
+        inputs["eigenvectors"],
+        inputs["dt"],
+    )
+    cpu = compute_eigen_sed(
+        inputs["velocities"],
+        inputs["unitcell_vectors"],
+        inputs["basis_index"],
+        inputs["masses"],
+        inputs["primitive_cell"],
+        inputs["supercell_cell"],
+        inputs["eigenvectors"],
+        inputs["dt"],
+        backend="cpu",
+    )
+
+    np.testing.assert_allclose(cpu.sed, default.sed)
+    np.testing.assert_allclose(cpu.frequencies_thz, default.frequencies_thz)
+    assert cpu.metadata["backend"] == "cpu"

--- a/tests/test_electron_kinematics.py
+++ b/tests/test_electron_kinematics.py
@@ -1,0 +1,74 @@
+import numpy as np
+import pytest
+
+from pySED.electron_kinematics import (
+    angular_resolution_to_q_sigma,
+    eels_qpoints_from_angle_axis,
+    electron_beta,
+    electron_wavelength_angstrom,
+    electron_wavenumber_per_angstrom,
+    longitudinal_momentum_transfer,
+    scattering_angles_to_qpoints,
+)
+
+
+def test_relativistic_electron_wavelength_at_200kev():
+    wavelength = electron_wavelength_angstrom(200000.0)
+
+    assert wavelength == pytest.approx(0.02508, rel=5e-4)
+    assert electron_wavenumber_per_angstrom(200000.0) == pytest.approx(2.0 * np.pi / wavelength)
+    assert 0.69 < electron_beta(200000.0) < 0.70
+
+
+def test_scattering_angles_to_qpoints_uses_mrad_axis():
+    qpoints = scattering_angles_to_qpoints(
+        theta_x=np.array([0.0, 10.0]),
+        theta_y=0.0,
+        beam_energy_ev=200000.0,
+        angle_unit="mrad",
+        include_longitudinal=False,
+    )
+
+    k0 = electron_wavenumber_per_angstrom(200000.0)
+    np.testing.assert_allclose(qpoints[:, 0], [0.0, k0 * 0.010])
+    np.testing.assert_allclose(qpoints[:, 1:], 0.0)
+
+
+def test_longitudinal_momentum_transfer_matches_hbar_v_formula():
+    q_parallel = longitudinal_momentum_transfer(100.0, 200000.0)
+    qpoint = scattering_angles_to_qpoints(
+        theta_x=0.0,
+        beam_energy_ev=200000.0,
+        energy_loss_ev=100.0,
+        include_longitudinal=True,
+    )
+
+    assert q_parallel == pytest.approx(0.0728, rel=5e-3)
+    assert qpoint.shape == (3,)
+    assert qpoint[2] == pytest.approx(q_parallel)
+
+
+def test_eels_angle_axis_direction_is_normalized():
+    qpoints = eels_qpoints_from_angle_axis(
+        np.array([0.0, 2.0]),
+        beam_energy_ev=100000.0,
+        direction=(1.0, 1.0),
+        angle_unit="mrad",
+    )
+
+    assert qpoints.shape == (2, 3)
+    assert qpoints[1, 0] == pytest.approx(qpoints[1, 1])
+    assert qpoints[1, 2] == 0.0
+
+
+def test_eels_angle_axis_rejects_zero_direction():
+    with pytest.raises(ValueError, match="direction"):
+        eels_qpoints_from_angle_axis([0.0, 1.0], 100000.0, direction=(0.0, 0.0))
+
+
+def test_angular_resolution_to_q_sigma_matches_small_angle_limit():
+    k0 = electron_wavenumber_per_angstrom(200000.0)
+
+    sigma_q = angular_resolution_to_q_sigma(2.0, 200000.0, angle_unit="mrad")
+
+    assert sigma_q == pytest.approx(k0 * 0.002)

--- a/tests/test_mode_visibility.py
+++ b/tests/test_mode_visibility.py
@@ -1,0 +1,247 @@
+import numpy as np
+import pytest
+
+from pySED.mode_visibility import (
+    build_one_phonon_decomposition_map_from_mode_spectra,
+    build_one_phonon_map,
+    build_one_phonon_map_from_mode_spectra,
+    compute_one_phonon_visibility,
+    compute_one_phonon_visibility_for_q_path,
+)
+
+
+def test_custom_one_phonon_visibility_reports_interference_and_direction_selection():
+    primitive = np.eye(3)
+    basis_positions = np.array([[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]])
+    masses = np.ones(2)
+    qpoints = np.array([[0.0, 0.0, 0.0]])
+    g_vectors = np.array([[1.0, 0.0, 0.0]])
+    eig = np.zeros((1, 2, 2, 3), dtype=complex)
+    eig[0, 0, :, 0] = [1.0, 1.0] / np.sqrt(2.0)
+    eig[0, 1, :, 0] = [1.0, -1.0] / np.sqrt(2.0)
+
+    result = compute_one_phonon_visibility(
+        qpoints,
+        g_vectors,
+        primitive,
+        basis_positions,
+        masses,
+        eig,
+        experiment="custom",
+    )
+
+    acoustic, optic = result.visibility[0, 0]
+    assert optic > acoustic
+    assert result.atom_interference[0, 0, 0] < 0.0
+    assert result.atom_interference[0, 0, 1] > 0.0
+    np.testing.assert_allclose(result.direction_visibility[0, 0, :, 1:], 0.0, atol=1e-14)
+    np.testing.assert_allclose(np.abs(result.amplitude) ** 2, result.visibility)
+
+
+def test_xray_one_phonon_visibility_uses_q_dependent_form_factors():
+    primitive = np.eye(3)
+    qpoints = np.array([[0.5, 0.0, 0.0]])
+    g_vectors = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+    eig = np.zeros((1, 1, 1, 3), dtype=complex)
+    eig[0, 0, 0, 0] = 1.0
+
+    result = compute_one_phonon_visibility(
+        qpoints,
+        g_vectors,
+        primitive,
+        basis_positions_reduced=np.array([[0.0, 0.0, 0.0]]),
+        masses=np.ones(1),
+        eigenvectors=eig,
+        atom_types=["C"],
+        experiment="xray",
+    )
+
+    assert result.scattering_weights.shape == (1, 2, 1)
+    assert result.scattering_weights[0, 1, 0] < result.scattering_weights[0, 0, 0]
+    assert result.metadata["weight_model"] == "Cromer-Mann X-ray form factors"
+
+
+def test_neutron_one_phonon_visibility_requires_atom_types():
+    eig = np.ones((1, 1, 1, 3), dtype=complex)
+
+    with pytest.raises(ValueError, match="atom_types"):
+        compute_one_phonon_visibility(
+            np.array([[0.0, 0.0, 0.0]]),
+            np.array([[1.0, 0.0, 0.0]]),
+            np.eye(3),
+            basis_positions_reduced=np.array([[0.0, 0.0, 0.0]]),
+            masses=np.ones(1),
+            eigenvectors=eig,
+            experiment="neutron",
+        )
+
+
+def test_frequency_power_applies_one_over_omega_visibility_factor():
+    eig = np.zeros((1, 2, 1, 3), dtype=complex)
+    eig[0, :, 0, 0] = 1.0
+
+    result = compute_one_phonon_visibility(
+        np.array([[1.0, 0.0, 0.0]]),
+        np.array([[0.0, 0.0, 0.0]]),
+        np.eye(3),
+        basis_positions_reduced=np.array([[0.0, 0.0, 0.0]]),
+        masses=np.ones(1),
+        eigenvectors=eig,
+        experiment="custom",
+        mode_frequencies=np.array([[1.0, 2.0]]),
+        frequency_power=-1,
+    )
+
+    np.testing.assert_allclose(result.visibility[0, 0, 0] / result.visibility[0, 0, 1], 2.0)
+
+
+def test_build_one_phonon_map_from_visibility():
+    eig = np.zeros((1, 1, 1, 3), dtype=complex)
+    eig[0, 0, 0, 0] = 1.0
+    visibility = compute_one_phonon_visibility(
+        np.array([[1.0, 0.0, 0.0]]),
+        np.array([[0.0, 0.0, 0.0]]),
+        np.eye(3),
+        basis_positions_reduced=np.array([[0.0, 0.0, 0.0]]),
+        masses=np.ones(1),
+        eigenvectors=eig,
+        experiment="custom",
+    )
+    energy = np.linspace(0.0, 10.0, 101)
+
+    scattering_map = build_one_phonon_map(
+        visibility,
+        mode_frequencies=np.array([[5.0]]),
+        energy_axis=energy,
+        broadening=0.2,
+        broadening_kind="gaussian",
+    )
+
+    assert scattering_map.intensity.shape == (1, 1, 101)
+    assert energy[np.argmax(scattering_map.intensity[0, 0])] == 5.0
+
+
+def test_build_one_phonon_map_from_mode_spectra():
+    eig = np.zeros((2, 2, 1, 3), dtype=complex)
+    eig[:, 0, 0, 0] = 1.0
+    eig[:, 1, 0, 1] = 1.0
+    visibility = compute_one_phonon_visibility(
+        np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]),
+        np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]]),
+        np.eye(3),
+        basis_positions_reduced=np.array([[0.0, 0.0, 0.0]]),
+        masses=np.ones(1),
+        eigenvectors=eig,
+        experiment="custom",
+    )
+    energy = np.array([1.0, 2.0, 3.0])
+    mode_spectra = np.zeros((3, 2, 2), dtype=float)
+    mode_spectra[:, 0, 0] = [1.0, 2.0, 3.0]
+    mode_spectra[:, 0, 1] = [4.0, 5.0, 6.0]
+    mode_spectra[:, 1, 0] = [7.0, 8.0, 9.0]
+    mode_spectra[:, 1, 1] = [10.0, 11.0, 12.0]
+
+    one_phonon_map = build_one_phonon_map_from_mode_spectra(visibility, mode_spectra, energy)
+    expected = np.einsum("qgm,eqm->qge", visibility.visibility, mode_spectra)
+
+    assert one_phonon_map.intensity.shape == (2, 2, 3)
+    np.testing.assert_allclose(one_phonon_map.intensity, expected)
+
+
+def test_pairwise_one_phonon_q_path_does_not_form_q_by_g_cartesian_product():
+    primitive = np.eye(3)
+    qpoints = np.array([[0.0, 0.0, 0.0], [0.25, 0.0, 0.0]])
+    g_vectors = np.array([[1.0, 0.0, 0.0], [2.0, 0.0, 0.0]])
+    eig = np.zeros((2, 1, 1, 3), dtype=complex)
+    eig[:, 0, 0, 0] = 1.0
+
+    product = compute_one_phonon_visibility(
+        qpoints,
+        g_vectors,
+        primitive,
+        basis_positions_reduced=np.array([[0.0, 0.0, 0.0]]),
+        masses=np.ones(1),
+        eigenvectors=eig,
+        experiment="custom",
+    )
+    path = compute_one_phonon_visibility_for_q_path(
+        qpoints,
+        g_vectors,
+        primitive,
+        basis_positions_reduced=np.array([[0.0, 0.0, 0.0]]),
+        masses=np.ones(1),
+        eigenvectors=eig,
+        experiment="custom",
+    )
+
+    assert product.visibility.shape == (2, 2, 1)
+    assert path.visibility.shape == (2, 1, 1)
+    np.testing.assert_allclose(path.Q_reduced[:, 0, :], qpoints + g_vectors)
+    assert path.metadata["pairwise_g_vectors"] is True
+
+
+def test_pairwise_one_phonon_q_path_validates_shape():
+    with pytest.raises(ValueError, match="pairwise"):
+        compute_one_phonon_visibility_for_q_path(
+            np.array([[0.0, 0.0, 0.0], [0.25, 0.0, 0.0]]),
+            np.array([[1.0, 0.0, 0.0]]),
+            np.eye(3),
+            basis_positions_reduced=np.array([[0.0, 0.0, 0.0]]),
+            masses=np.ones(1),
+            eigenvectors=np.ones((2, 1, 1, 3), dtype=complex),
+            experiment="custom",
+        )
+
+
+def test_one_phonon_decomposition_map_preserves_atom_interference_identity():
+    primitive = np.eye(3)
+    basis_positions = np.array([[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]])
+    masses = np.ones(2)
+    qpoints = np.array([[0.0, 0.0, 0.0]])
+    g_vectors = np.array([[1.0, 0.0, 0.0]])
+    eig = np.zeros((1, 2, 2, 3), dtype=complex)
+    eig[0, 0, :, 0] = [1.0, 1.0] / np.sqrt(2.0)
+    eig[0, 1, :, 0] = [1.0, -1.0] / np.sqrt(2.0)
+
+    visibility = compute_one_phonon_visibility(
+        qpoints,
+        g_vectors,
+        primitive,
+        basis_positions,
+        masses,
+        eig,
+        experiment="custom",
+    )
+    energy = np.array([1.0, 2.0, 3.0])
+    mode_spectra = np.zeros((3, 1, 2), dtype=float)
+    mode_spectra[:, 0, 0] = [1.0, 2.0, 3.0]
+    mode_spectra[:, 0, 1] = [4.0, 5.0, 6.0]
+
+    diagnostic = build_one_phonon_decomposition_map_from_mode_spectra(
+        visibility,
+        mode_spectra,
+        energy,
+    )
+
+    assert diagnostic.atom_intensity.shape == (1, 1, 2, 3)
+    assert diagnostic.direction_intensity.shape == (1, 1, 3, 3)
+    np.testing.assert_allclose(
+        diagnostic.intensity,
+        np.sum(diagnostic.atom_intensity, axis=2) + diagnostic.atom_interference_intensity,
+    )
+
+
+def test_build_one_phonon_map_from_mode_spectra_validates_shape():
+    eig = np.ones((1, 1, 1, 3), dtype=complex)
+    visibility = compute_one_phonon_visibility(
+        np.array([[0.0, 0.0, 0.0]]),
+        np.array([[1.0, 0.0, 0.0]]),
+        np.eye(3),
+        basis_positions_reduced=np.array([[0.0, 0.0, 0.0]]),
+        masses=np.ones(1),
+        eigenvectors=eig,
+        experiment="custom",
+    )
+
+    with pytest.raises(ValueError, match="mode_spectra"):
+        build_one_phonon_map_from_mode_spectra(visibility, np.ones((1, 1)), np.ones(1))

--- a/tests/test_probe_weights.py
+++ b/tests/test_probe_weights.py
@@ -1,0 +1,88 @@
+import numpy as np
+
+from pySED.probe_weights import (
+    CROMER_MANN_COEFFICIENTS,
+    atomic_number_weights,
+    cromer_mann_form_factor,
+    electron_form_factor_weights,
+    mott_bethe_electron_form_factor,
+    xray_form_factor_weights,
+)
+
+
+def test_cromer_mann_q_zero_matches_atomic_number():
+    for symbol in ("C", "O", "Si", "Mo", "W"):
+        q_zero = cromer_mann_form_factor(0.0, CROMER_MANN_COEFFICIENTS[symbol])
+        atomic_number = atomic_number_weights([symbol])[0]
+        np.testing.assert_allclose(q_zero, atomic_number, rtol=2e-3, atol=5e-3)
+
+
+def test_xray_form_factor_weights_are_q_dependent():
+    qpoints = np.array([[0.0, 0.0, 0.0], [8.0, 0.0, 0.0]])
+    weights = xray_form_factor_weights(["C", "Si"], qpoints)
+
+    assert weights.shape == (2, 2)
+    assert np.all(weights[1] < weights[0])
+    np.testing.assert_allclose(weights[0], atomic_number_weights(["C", "Si"]), atol=5e-3)
+
+
+def test_xray_form_factor_missing_element_options():
+    qpoints = np.array([[1.0, 0.0, 0.0]])
+
+    zero = xray_form_factor_weights(["Unknown"], qpoints, missing="zero")
+    np.testing.assert_allclose(zero, [[0.0]])
+
+    try:
+        xray_form_factor_weights(["Unknown"], qpoints, missing="raise")
+    except KeyError:
+        pass
+    else:
+        raise AssertionError("missing='raise' should reject elements without coefficients")
+
+
+def test_user_supplied_cromer_mann_coefficients_override_builtin():
+    qpoints = np.array([[0.0, 0.0, 0.0]])
+    table = {"C": {"a": (1.0, 0.0, 0.0, 0.0), "b": (0.0, 0.0, 0.0, 0.0), "c": 0.5}}
+    weights = xray_form_factor_weights(["C"], qpoints, coefficients_table=table)
+
+    np.testing.assert_allclose(weights, [[1.5]])
+
+
+def test_mott_bethe_electron_form_factor_handles_scalar_and_small_q():
+    scalar = mott_bethe_electron_form_factor(0.0, 6, CROMER_MANN_COEFFICIENTS["C"])
+    vector = mott_bethe_electron_form_factor(
+        np.array([0.0, 2.0]),
+        6,
+        CROMER_MANN_COEFFICIENTS["C"],
+    )
+
+    assert isinstance(scalar, float)
+    assert scalar > 0.0
+    assert vector.shape == (2,)
+    assert np.all(np.isfinite(vector))
+    assert np.all(vector > 0.0)
+    assert vector[1] != vector[0]
+
+
+def test_electron_form_factor_weights_are_q_dependent():
+    qpoints = np.array([[0.5, 0.0, 0.0], [4.0, 0.0, 0.0]])
+    weights = electron_form_factor_weights(["C", "Si"], qpoints)
+
+    assert weights.shape == (2, 2)
+    assert np.all(np.isfinite(weights))
+    assert np.all(weights > 0.0)
+    assert not np.allclose(weights[0], weights[1])
+
+
+def test_electron_form_factor_missing_element_options():
+    qpoints = np.array([[1.0, 0.0, 0.0]])
+
+    zero = electron_form_factor_weights(["Unknown"], qpoints, missing="zero")
+    np.testing.assert_allclose(zero, [[0.0]])
+
+    try:
+        electron_form_factor_weights(["Unknown"], qpoints, missing="raise")
+    except KeyError:
+        pass
+    else:
+        raise AssertionError("missing='raise' should reject elements without electron data")

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,46 @@
+import numpy as np
+
+import pySED
+
+
+def test_scattering_objects_are_available_from_package_top_level():
+    advisor = pySED.QAdvisor(np.eye(3), np.diag([2.0, 1.0, 1.0]))
+    assert advisor.is_commensurate([0.5, 0.0, 0.0])
+
+    assert pySED.build_eels_decomposition_map_from_mode_spectra is not None
+    assert pySED.build_one_phonon_decomposition_map_from_mode_spectra is not None
+    assert pySED.compute_coherent_dsf_via_correlation is not None
+    assert pySED.compute_current_correlation_workflow is not None
+    assert pySED.compute_dsf is not None
+    assert pySED.compute_eels_workflow is not None
+    assert pySED.compute_eels_workflow_from_angle_axis is not None
+    assert pySED.compute_eels_workflow_from_q_path is not None
+    assert pySED.dsf_to_scattering_map is not None
+    assert pySED.compute_mode_visibility_for_q_path is not None
+    assert pySED.compute_one_phonon_visibility_for_q_path is not None
+    assert pySED.compute_one_phonon_workflow_from_q_path is not None
+    assert pySED.compute_partial_dsf is not None
+    assert pySED.compute_partial_dsf_workflow is not None
+    assert pySED.angular_resolution_to_q_sigma is not None
+    assert pySED.diagnose_mode_visibility is not None
+    assert pySED.eels_qpoints_from_angle_axis is not None
+    assert pySED.scattering_angles_to_qpoints is not None
+    assert pySED.write_map_comparison_report is not None
+    assert pySED.write_scattering_workflow_bundle is not None
+    assert pySED.workflow_export_summary is not None
+    assert pySED.run_scattering_from_input is not None
+    assert pySED.comparison_summary is not None
+    assert pySED.comparison_linecut_records is not None
+    assert pySED.estimate_selected_q_efficiency is not None
+    assert pySED.qpoints_from_mesh is not None
+    assert pySED.qpoints_from_path_axis is not None
+    assert pySED.qpoints_from_path_segments is not None
+    assert pySED.split_extended_zone_qpoints is not None
+    assert pySED.ScatteringMap is not None
+    assert pySED.QPointMesh is not None
+    assert pySED.QPathSegments is not None
+    assert pySED.SelectedQEfficiencyReport is not None
+    assert pySED.CurrentCorrelationResult is not None
+    assert pySED.PartialDSFResult is not None
+    assert pySED.current_correlation_to_scattering_map is not None
+    assert pySED.partial_dsf_to_scattering_map is not None

--- a/tests/test_q_advisor.py
+++ b/tests/test_q_advisor.py
@@ -1,0 +1,275 @@
+import numpy as np
+import pytest
+
+from pySED.compare_experiment import ScatteringMap
+from pySED.q_advisor import (
+    QAdvisor,
+    estimate_selected_q_efficiency,
+    qpoints_from_mesh,
+    qpoints_from_path_axis,
+    qpoints_from_path_segments,
+    split_extended_zone_qpoints,
+    suggest_diagonal_supercell,
+)
+
+
+def test_commensurate_validation_and_nearest_point():
+    primitive = np.eye(3)
+    supercell = np.diag([4.0, 4.0, 1.0])
+    advisor = QAdvisor(primitive, supercell)
+
+    assert advisor.is_commensurate([0.25, 0.0, 0.0])
+    assert not advisor.is_commensurate([0.20, 0.0, 0.0])
+
+    advice = advisor.nearest_commensurate([0.26, 0.0, 0.0])
+    np.testing.assert_allclose(advice.nearest_reduced, [0.25, 0.0, 0.0])
+    assert advice.error_cartesian > 0
+
+
+def test_commensurate_path_uses_supercell_grid():
+    advisor = QAdvisor(np.eye(3), np.diag([4.0, 1.0, 1.0]))
+    qpoints, fractions = advisor.build_commensurate_path([0, 0, 0], [0.5, 0, 0])
+
+    np.testing.assert_allclose(qpoints, [[0, 0, 0], [0.25, 0, 0], [0.5, 0, 0]])
+    np.testing.assert_allclose(fractions, [0.0, 0.5, 1.0])
+
+
+def test_suggest_diagonal_supercell_from_target_qpoints():
+    qpoints = np.array([[1 / 3, 0, 0], [0, 0.25, 0], [0, 0, 0.5]])
+    np.testing.assert_array_equal(suggest_diagonal_supercell(qpoints), [3, 4, 2])
+
+
+def test_cartesian_experimental_qpoints_are_mapped_to_commensurate_grid():
+    advisor = QAdvisor(np.eye(3), np.diag([4.0, 4.0, 1.0]))
+    cartesian_q = np.array([[0.26 * 2 * np.pi, 0.0, 0.0]])
+
+    advice = advisor.advise_cartesian_qpoints(cartesian_q)[0]
+
+    np.testing.assert_allclose(advice.nearest_reduced, [0.25, 0.0, 0.0])
+    np.testing.assert_allclose(advice.nearest_cartesian, [0.5 * np.pi, 0.0, 0.0])
+    assert advice.error_cartesian > 0
+
+
+def test_experimental_path_report_summarizes_errors_and_exports_csv(tmp_path):
+    advisor = QAdvisor(np.eye(3), np.diag([4.0, 4.0, 1.0]))
+    qpoints = np.array([[0.25, 0.0, 0.0], [0.20, 0.0, 0.0]])
+
+    report = advisor.advise_experimental_path(qpoints, coordinates="reduced")
+
+    assert report.num_points == 2
+    assert report.num_commensurate == 1
+    assert not report.all_commensurate
+    np.testing.assert_allclose(report.nearest_reduced[1], [0.25, 0.0, 0.0])
+    np.testing.assert_array_equal(report.suggested_diagonal_supercell, [20, 1, 1])
+    assert report.summary()["max_error_cartesian"] > 0.0
+    assert "suggested_diagonal_supercell" in report.to_table()
+
+    csv_path = tmp_path / "q_report.csv"
+    report.write_csv(csv_path)
+    text = csv_path.read_text(encoding="utf-8")
+    assert "requested_reduced_1" in text
+    assert "False" in text
+
+
+def test_nearest_commensurate_can_preserve_extended_zone_image():
+    advisor = QAdvisor(np.eye(3), np.diag([4.0, 1.0, 1.0]))
+
+    folded = advisor.nearest_commensurate([1.26, 0.0, 0.0])
+    preserved = advisor.nearest_commensurate([1.26, 0.0, 0.0], preserve_image=True)
+
+    np.testing.assert_allclose(folded.nearest_reduced, [0.25, 0.0, 0.0])
+    np.testing.assert_allclose(preserved.nearest_reduced, [1.25, 0.0, 0.0])
+    np.testing.assert_allclose(preserved.nearest_cartesian, [2.5 * np.pi, 0.0, 0.0])
+
+
+def test_experimental_path_report_preserves_cartesian_extended_zone_image():
+    advisor = QAdvisor(np.eye(3), np.diag([4.0, 1.0, 1.0]))
+    cartesian_q = np.array([[1.26 * 2.0 * np.pi, 0.0, 0.0]])
+
+    report = advisor.advise_experimental_path(cartesian_q, coordinates="cartesian")
+
+    np.testing.assert_allclose(report.requested_reduced, [[1.26, 0.0, 0.0]])
+    np.testing.assert_allclose(report.nearest_reduced, [[1.25, 0.0, 0.0]])
+    np.testing.assert_allclose(report.nearest_cartesian, [[2.5 * np.pi, 0.0, 0.0]])
+    np.testing.assert_array_equal(report.suggested_diagonal_supercell, [50, 1, 1])
+
+
+def test_split_extended_zone_qpoints_returns_folded_q_and_integer_g():
+    q_folded, g_vectors = split_extended_zone_qpoints(
+        np.array([[1.25, 0.0, 0.0], [0.75, 0.0, 0.0]])
+    )
+
+    np.testing.assert_allclose(q_folded, [[0.25, 0.0, 0.0], [-0.25, 0.0, 0.0]])
+    np.testing.assert_array_equal(g_vectors, [[1, 0, 0], [1, 0, 0]])
+    np.testing.assert_allclose(q_folded + g_vectors, [[1.25, 0.0, 0.0], [0.75, 0.0, 0.0]])
+
+
+def test_extended_zone_q_path_plan_maps_experimental_q_to_pairwise_q_and_g(tmp_path):
+    advisor = QAdvisor(np.eye(3), np.diag([4.0, 1.0, 1.0]))
+
+    plan = advisor.plan_extended_zone_q_path(
+        np.array([[1.26 * 2.0 * np.pi, 0.0, 0.0]]),
+        coordinates="cartesian",
+        q_policy="nearest",
+        max_error_reduced=0.02,
+    )
+
+    np.testing.assert_allclose(plan.Q_reduced, [[1.25, 0.0, 0.0]])
+    np.testing.assert_allclose(plan.qpoints_reduced, [[0.25, 0.0, 0.0]])
+    np.testing.assert_array_equal(plan.g_vectors_reduced, [[1, 0, 0]])
+    np.testing.assert_allclose(plan.Q_reduced, plan.qpoints_reduced + plan.g_vectors_reduced)
+
+    phonopy_path = tmp_path / "phonopy_qpoints.dat"
+    plan.write_phonopy_qpoints(phonopy_path)
+    np.testing.assert_allclose(np.loadtxt(phonopy_path).reshape(1, 3), [[0.25, 0.0, 0.0]])
+
+    csv_path = tmp_path / "extended_q_plan.csv"
+    plan.write_csv(csv_path)
+    text = csv_path.read_text(encoding="utf-8")
+    assert "folded_q_reduced_1" in text
+    assert "G_reduced_1" in text
+
+
+def test_qpoints_from_path_axis_interpolates_vector_endpoints():
+    qpoints = qpoints_from_path_axis(
+        q_axis=np.array([10.0, 20.0, 30.0]),
+        start_qpoint=np.array([0.0, 0.0, 0.0]),
+        end_qpoint=np.array([0.5, 0.0, 0.0]),
+    )
+
+    np.testing.assert_allclose(qpoints, [[0.0, 0.0, 0.0], [0.25, 0.0, 0.0], [0.5, 0.0, 0.0]])
+
+
+def test_qpoints_from_mesh_generates_selected_q_grid_and_reshape():
+    mesh = qpoints_from_mesh([-0.25, 0.25, 3], 0.0, [1.0, 1.5, 2])
+
+    assert mesh.mesh_shape == (3, 1, 2)
+    np.testing.assert_allclose(mesh.axes[0], [-0.25, 0.0, 0.25])
+    np.testing.assert_allclose(
+        mesh.qpoints_reduced,
+        [
+            [-0.25, 0.0, 1.0],
+            [-0.25, 0.0, 1.5],
+            [0.0, 0.0, 1.0],
+            [0.0, 0.0, 1.5],
+            [0.25, 0.0, 1.0],
+            [0.25, 0.0, 1.5],
+        ],
+    )
+
+    values = np.arange(6)
+    np.testing.assert_array_equal(mesh.reshape_values(values), values.reshape(3, 1, 2))
+
+
+def test_qpoints_from_path_segments_matches_selected_path_convention():
+    path = qpoints_from_path_segments(
+        starts=np.array([[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]]),
+        ends=np.array([[0.5, 0.0, 0.0], [0.5, 0.5, 0.0]]),
+        steps=np.array([2, 2]),
+    )
+
+    np.testing.assert_allclose(
+        path.qpoints_reduced,
+        [
+            [0.0, 0.0, 0.0],
+            [0.25, 0.0, 0.0],
+            [0.5, 0.0, 0.0],
+            [0.5, 0.25, 0.0],
+        ],
+    )
+    np.testing.assert_allclose(path.path_axis, [0.0, 0.25, 0.5, 0.75])
+    np.testing.assert_array_equal(path.segment_start_indices, [0, 2])
+    np.testing.assert_array_equal(path.segment_end_indices, [1, 3])
+
+
+def test_selected_mesh_points_can_be_checked_by_q_advisor():
+    mesh = qpoints_from_mesh([0.20, 0.30, 2], 0.0, 0.0)
+    advisor = QAdvisor(np.eye(3), np.diag([4.0, 1.0, 1.0]))
+
+    report = advisor.advise_experimental_path(mesh.qpoints_reduced, coordinates="reduced")
+
+    assert not report.all_commensurate
+    np.testing.assert_allclose(report.nearest_reduced[:, 0], [0.25, 0.25])
+    np.testing.assert_array_equal(report.suggested_diagonal_supercell, [10, 1, 1])
+
+
+def test_selected_q_efficiency_report_estimates_full_grid_savings():
+    report = estimate_selected_q_efficiency(
+        num_selected_qpoints=8,
+        num_full_qpoints=64,
+        num_frames=16,
+        num_atoms=10,
+    )
+
+    assert report.selected_fraction == 0.125
+    assert report.qpoint_reduction_factor == 8.0
+    assert report.selected_phase_evaluations == 1280.0
+    assert report.full_phase_evaluations == 10240.0
+    assert report.selected_fft_work_units == 8 * 16 * 4
+    assert "q-point reduction factor" in report.to_table()
+    assert report.summary()["num_atoms"] == 10
+
+
+def test_q_advisor_selected_q_efficiency_uses_supercell_grid_size():
+    advisor = QAdvisor(np.eye(3), np.diag([4.0, 4.0, 2.0]))
+    mesh = qpoints_from_mesh([0.0, 0.25, 2], 0.0, 0.0)
+
+    report = advisor.estimate_selected_q_efficiency(
+        mesh.qpoints_reduced,
+        num_frames=32,
+        num_atoms=5,
+    )
+
+    assert report.num_full_qpoints == 32
+    assert report.num_selected_qpoints == 2
+    assert report.qpoint_reduction_factor == 16.0
+    assert report.full_phase_evaluations / report.selected_phase_evaluations == 16.0
+
+
+def test_map_q_axis_advisor_uses_calibrated_image_axis():
+    scattering_map = ScatteringMap(
+        q_axis=np.array([0.0, 1.0, 2.0]),
+        energy_axis=np.array([0.0, 10.0]),
+        intensity=np.ones((3, 2)),
+    )
+    advisor = QAdvisor(np.eye(3), np.diag([4.0, 1.0, 1.0]))
+
+    report = advisor.advise_map_q_axis(
+        scattering_map,
+        start_qpoint=np.array([0.0, 0.0, 0.0]),
+        end_qpoint=np.array([0.5, 0.0, 0.0]),
+        coordinates="reduced",
+    )
+    plan = advisor.plan_map_q_axis(
+        scattering_map,
+        start_qpoint=np.array([1.0, 0.0, 0.0]),
+        end_qpoint=np.array([1.5, 0.0, 0.0]),
+        coordinates="reduced",
+        q_policy="strict",
+    )
+
+    assert report.all_commensurate
+    np.testing.assert_allclose(report.requested_reduced[:, 0], [0.0, 0.25, 0.5])
+    np.testing.assert_allclose(plan.Q_reduced[:, 0], [1.0, 1.25, 1.5])
+    np.testing.assert_allclose(plan.qpoints_reduced[:, 0], [0.0, 0.25, 0.5])
+    np.testing.assert_array_equal(plan.g_vectors_reduced[:, 0], [1, 1, 1])
+
+
+def test_extended_zone_q_path_plan_strict_rejects_non_commensurate_q():
+    advisor = QAdvisor(np.eye(3), np.diag([4.0, 1.0, 1.0]))
+
+    with pytest.raises(ValueError, match="non-commensurate"):
+        advisor.plan_extended_zone_q_path(
+            np.array([[0.26, 0.0, 0.0]]),
+            coordinates="reduced",
+            q_policy="strict",
+        )
+
+
+def test_write_phonopy_qpoints_rejects_non_commensurate_points(tmp_path):
+    advisor = QAdvisor(np.eye(3), np.diag([4.0, 4.0, 1.0]))
+    qpoints = np.array([[0.25, 0.0, 0.0], [0.20, 0.0, 0.0]])
+
+    assert not advisor.validate_qpoints(qpoints)
+    with pytest.raises(ValueError, match="commensurate"):
+        advisor.write_phonopy_qpoints(qpoints, tmp_path / "qpoints.dat")

--- a/tests/test_quantum_correction.py
+++ b/tests/test_quantum_correction.py
@@ -1,0 +1,43 @@
+import numpy as np
+import pytest
+
+from pySED.quantum_correction import (
+    PLANCK_MEV_THZ,
+    apply_quantum_correction,
+    bose_population,
+    classical_to_quantum_factor,
+    convert_energy_axis,
+)
+
+
+def test_energy_axis_conversion_thz_to_mev():
+    np.testing.assert_allclose(convert_energy_axis([1.0], "thz", "meV"), [PLANCK_MEV_THZ])
+    np.testing.assert_allclose(convert_energy_axis([PLANCK_MEV_THZ], "meV", "thz"), [1.0])
+
+
+def test_quantum_factor_obeys_detailed_balance():
+    energy = np.array([-10.0, 0.0, 10.0])
+    temperature = 300.0
+    factor = classical_to_quantum_factor(energy, temperature, unit="meV")
+
+    assert factor[1] == pytest.approx(1.0)
+    np.testing.assert_allclose(
+        factor[0] / factor[2],
+        np.exp(-10.0 / (0.08617333262145 * temperature)),
+    )
+
+
+def test_apply_quantum_correction_multiplies_selected_axis():
+    intensity = np.ones((2, 3))
+    energy = np.array([0.0, 5.0, 10.0])
+    corrected = apply_quantum_correction(intensity, energy, 300.0, unit="meV", axis_index=1)
+    factor = classical_to_quantum_factor(energy, 300.0, unit="meV")
+
+    np.testing.assert_allclose(corrected[0], factor)
+    np.testing.assert_allclose(corrected[1], factor)
+
+
+def test_bose_population_positive_energy():
+    population = bose_population(np.array([10.0]), 300.0, unit="meV")
+
+    assert population[0] > 0

--- a/tests/test_scattering_export.py
+++ b/tests/test_scattering_export.py
@@ -1,0 +1,166 @@
+import csv
+import json
+
+import numpy as np
+
+from pySED.compare_experiment import ScatteringMap
+from pySED.eigen_sed import EigenvectorSet
+from pySED.scattering_export import workflow_export_summary, write_scattering_workflow_bundle
+from pySED.scattering_workflow import compute_current_correlation_workflow
+from pySED.scattering_workflow import compute_dsf_workflow, compute_eels_workflow_from_q_path
+from pySED.scattering_workflow import compute_partial_dsf_workflow
+
+
+def _eels_q_path_result_with_comparison():
+    n_frames = 32
+    dt = 1e-12
+    velocities = np.zeros((n_frames, 4, 3), dtype=float)
+    velocities[:, :, 0] = 1.0
+    eig = np.zeros((2, 1, 1, 3), dtype=complex)
+    eig[:, 0, 0, 0] = 1.0
+    eigset = EigenvectorSet(
+        qpoints_reduced=np.array([[0.0, 0.0, 0.0], [0.25, 0.0, 0.0]]),
+        frequencies=np.array([[0.0], [0.0]], dtype=float),
+        eigenvectors=eig,
+    )
+
+    preliminary = compute_eels_workflow_from_q_path(
+        velocities=velocities,
+        unitcell_vectors=np.array(
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0], [3.0, 0.0, 0.0]]
+        ),
+        basis_index=np.array([1, 1, 1, 1]),
+        masses=np.array([1.0]),
+        primitive_cell=np.eye(3),
+        supercell_cell=np.diag([4.0, 1.0, 1.0]),
+        eigenvectors=eigset,
+        basis_positions_reduced=np.array([[0.0, 0.0, 0.0]]),
+        experimental_qpoints=np.array([[1.0 * 2.0 * np.pi, 0.0, 0.0], [2.25 * 2.0 * np.pi, 0.0, 0.0]]),
+        dt=dt,
+        qpoint_coordinates="cartesian",
+    )
+    experimental = ScatteringMap(
+        preliminary.scattering_map.q_axis,
+        preliminary.scattering_map.energy_axis,
+        preliminary.scattering_map.intensity.copy(),
+    )
+    return compute_eels_workflow_from_q_path(
+        velocities=velocities,
+        unitcell_vectors=np.array(
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0], [3.0, 0.0, 0.0]]
+        ),
+        basis_index=np.array([1, 1, 1, 1]),
+        masses=np.array([1.0]),
+        primitive_cell=np.eye(3),
+        supercell_cell=np.diag([4.0, 1.0, 1.0]),
+        eigenvectors=eigset,
+        basis_positions_reduced=np.array([[0.0, 0.0, 0.0]]),
+        experimental_qpoints=np.array([[1.0 * 2.0 * np.pi, 0.0, 0.0], [2.25 * 2.0 * np.pi, 0.0, 0.0]]),
+        dt=dt,
+        qpoint_coordinates="cartesian",
+        experimental_map=experimental,
+        sigma_q=0.0,
+        sigma_energy=0.0,
+    )
+
+
+def test_scattering_workflow_bundle_exports_eels_artifacts(tmp_path):
+    result = _eels_q_path_result_with_comparison()
+
+    written = write_scattering_workflow_bundle(
+        result,
+        tmp_path,
+        prefix="eels",
+        atom_labels=["C"],
+        linecut_q_indices=[0],
+        linecut_energy_indices=[0],
+    )
+
+    expected_keys = {
+        "summary",
+        "q_plan",
+        "phonopy_qpoints",
+        "visibility_diagnostics",
+        "scattering_map",
+        "comparison_summary",
+        "comparison_residual",
+        "comparison_peaks",
+        "comparison_linecuts",
+    }
+    assert expected_keys <= set(written)
+
+    with open(written["summary"], "r", encoding="utf-8") as handle:
+        summary = json.load(handle)
+    with open(written["visibility_diagnostics"], "r", encoding="utf-8") as handle:
+        diagnostic_rows = list(csv.DictReader(handle))
+
+    assert summary["workflow_type"] == "EELSWorkflowResult"
+    assert summary["has_q_plan"] is True
+    assert summary["comparison"]["rmse"] < 1e-30
+    assert diagnostic_rows[0]["dominant_atom_label"] == "C"
+    np.testing.assert_allclose(np.loadtxt(written["phonopy_qpoints"]), [[0.0, 0.0, 0.0], [0.25, 0.0, 0.0]])
+
+
+def test_scattering_workflow_bundle_exports_dsf_q_advice(tmp_path):
+    positions = np.zeros((16, 1, 3), dtype=float)
+    result = compute_dsf_workflow(
+        positions,
+        qpoints=np.array([[0.26, 0.0, 0.0]]),
+        primitive_cell=np.eye(3),
+        supercell_cell=np.diag([4.0, 1.0, 1.0]),
+        dt=1e-12,
+        qpoint_coordinates="reduced",
+        q_policy="nearest",
+        experiment="custom",
+    )
+
+    summary = workflow_export_summary(result)
+    written = write_scattering_workflow_bundle(result, tmp_path, prefix="dsf")
+
+    assert summary["workflow_type"] == "DSFWorkflowResult"
+    assert summary["q_advice"]["num_commensurate"] == 0
+    assert "q_advice" in written
+    assert "visibility_diagnostics" not in written
+    assert "scattering_map" in written
+
+
+def test_scattering_workflow_bundle_exports_partial_and_current_metadata(tmp_path):
+    positions = np.zeros((16, 2, 3), dtype=float)
+    positions[:, 1, 0] = np.linspace(0.0, 0.5, 16)
+    velocities = np.zeros_like(positions)
+    velocities[:, :, 0] = 1.0
+
+    partial = compute_partial_dsf_workflow(
+        positions,
+        qpoints=np.array([[0.25, 0.0, 0.0]]),
+        primitive_cell=np.eye(3),
+        supercell_cell=np.diag([4.0, 1.0, 1.0]),
+        dt=1e-12,
+        atom_types=["A", "B"],
+        qpoint_coordinates="reduced",
+        q_policy="strict",
+    )
+    current = compute_current_correlation_workflow(
+        positions,
+        velocities,
+        qpoints=np.array([[0.25, 0.0, 0.0]]),
+        primitive_cell=np.eye(3),
+        supercell_cell=np.diag([4.0, 1.0, 1.0]),
+        dt=1e-12,
+        qpoint_coordinates="reduced",
+        q_policy="strict",
+    )
+
+    partial_summary = workflow_export_summary(partial)
+    current_summary = workflow_export_summary(current)
+    partial_written = write_scattering_workflow_bundle(partial, tmp_path / "partial", prefix="partial")
+    current_written = write_scattering_workflow_bundle(current, tmp_path / "current", prefix="current")
+
+    assert partial_summary["workflow_type"] == "PartialDSFWorkflowResult"
+    assert partial_summary["partial_dsf_metadata"]["q_policy"] == "strict"
+    assert current_summary["workflow_type"] == "CurrentCorrelationWorkflowResult"
+    assert current_summary["current_metadata"]["uncertainty"] == "standard error of the block-averaged spectra"
+    assert "q_advice" in partial_written
+    assert "scattering_map" in partial_written
+    assert "q_advice" in current_written
+    assert "scattering_map" in current_written

--- a/tests/test_scattering_input.py
+++ b/tests/test_scattering_input.py
@@ -1,0 +1,124 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from pySED import My_Parsers
+from pySED.scattering_input import ScatteringInputError, run_q_advisor_from_input
+
+
+def _write_input(tmp_path, text):
+    path = tmp_path / "input_SED.in"
+    path.write_text(text.strip() + "\n", encoding="utf-8")
+    return path
+
+
+def test_input_parser_handles_utf8_bom(tmp_path):
+    path = tmp_path / "input_SED.in"
+    path.write_bytes(b"\xef\xbb\xbfnum_atoms = 2\n")
+
+    params = My_Parsers.get_parse_input(str(path))
+
+    assert params.num_atoms == 2
+
+
+def test_scattering_mesh_input_writes_q_advisor_outputs(tmp_path):
+    prefix = tmp_path / "mesh_report"
+    input_file = _write_input(
+        tmp_path,
+        """
+        num_atoms = 2
+        total_num_steps = 16
+        time_step = 1.0
+        output_data_stride = 1
+        prim_unitcell = 1 0 0  0 1 0  0 0 1
+        supercell_dim = 4 1 1
+        scattering = 1
+        scattering_mode = q_advisor
+        scattering_qpoints_option = mesh
+        scattering_q_mesh_H = 0.20 0.30 2
+        scattering_q_mesh_K = 0.0
+        scattering_q_mesh_L = 0.0
+        scattering_q_policy = nearest
+        scattering_output_prefix = %s
+        """ % prefix,
+    )
+
+    params = My_Parsers.get_parse_input(str(input_file))
+    result = run_q_advisor_from_input(params)
+
+    report = result["report"]
+    assert not report.all_commensurate
+    np.testing.assert_allclose(report.nearest_reduced[:, 0], [0.25, 0.25])
+    assert result["efficiency"].qpoint_reduction_factor == 2.0
+
+    for path in result["written_files"].values():
+        assert Path(path).exists()
+
+    summary = Path(result["written_files"]["summary"]).read_text(encoding="utf-8")
+    assert "q-point reduction factor" in summary
+    assert "suggested_diagonal_supercell = [10, 1, 1]" in summary
+
+
+def test_scattering_strict_input_rejects_non_commensurate_q_but_writes_report(tmp_path):
+    prefix = tmp_path / "strict_report"
+    input_file = _write_input(
+        tmp_path,
+        """
+        num_atoms = 2
+        total_num_steps = 16
+        time_step = 1.0
+        output_data_stride = 1
+        prim_unitcell = 1 0 0  0 1 0  0 0 1
+        supercell_dim = 4 1 1
+        scattering = 1
+        scattering_mode = q_advisor
+        scattering_qpoints_option = points
+        scattering_qpoints = 0.20 0.0 0.0
+        scattering_q_policy = strict
+        scattering_output_prefix = %s
+        """ % prefix,
+    )
+
+    params = My_Parsers.get_parse_input(str(input_file))
+    with pytest.raises(ScatteringInputError) as exc:
+        run_q_advisor_from_input(params)
+
+    assert "non-commensurate" in str(exc.value)
+    assert Path(exc.value.written_files["summary"]).exists()
+    assert Path(exc.value.written_files["nearest_qpoints_reduced"]).exists()
+
+
+def test_scattering_path_input_uses_q_path_steps(tmp_path):
+    prefix = tmp_path / "path_report"
+    input_file = _write_input(
+        tmp_path,
+        """
+        num_atoms = 2
+        total_num_steps = 16
+        time_step = 1.0
+        output_data_stride = 1
+        prim_unitcell = 1 0 0  0 1 0  0 0 1
+        supercell_dim = 4 1 1
+        num_qpaths = 1
+        q_path = 0.0 0.0 0.0  0.5 0.0 0.0
+        scattering = 1
+        scattering_mode = q_advisor
+        scattering_qpoints_option = path
+        scattering_q_path_steps = 2
+        scattering_q_policy = strict
+        scattering_output_prefix = %s
+        """ % prefix,
+    )
+
+    params = My_Parsers.get_parse_input(str(input_file))
+    result = run_q_advisor_from_input(params)
+
+    report = result["report"]
+    assert report.all_commensurate
+    assert report.num_points == 3
+    np.testing.assert_allclose(report.requested_reduced[:, 0], [0.0, 0.25, 0.5])
+    np.testing.assert_allclose(
+        np.loadtxt(result["written_files"]["phonopy_qpoints_reduced"]).reshape(-1, 3)[:, 0],
+        [0.0, 0.25, 0.5],
+    )

--- a/tests/test_scattering_kernel.py
+++ b/tests/test_scattering_kernel.py
@@ -1,0 +1,66 @@
+import numpy as np
+from scipy.fft import fft
+
+from pySED.scattering_kernel import (
+    circular_autocorrelation,
+    density_amplitude,
+    density_amplitude_from_phase,
+    fft_power,
+    frequency_grid,
+    phase_factors,
+    resolve_backend,
+    standard_error,
+    to_numpy,
+)
+
+
+def test_resolve_cpu_backend_and_to_numpy():
+    backend = resolve_backend("cpu")
+    assert backend.name == "cpu"
+    arr = backend.xp.asarray([1.0, 2.0])
+    np.testing.assert_allclose(to_numpy(arr, backend), [1.0, 2.0])
+
+
+def test_cupy_backend_is_optional():
+    try:
+        backend = resolve_backend("cupy")
+    except ImportError as exc:
+        assert "CuPy backend requested" in str(exc)
+    else:
+        assert backend.name == "cupy"
+
+
+def test_density_amplitude_matches_manual_phase_weighting():
+    positions = np.array(
+        [
+            [[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]],
+            [[0.25, 0.0, 0.0], [0.75, 0.0, 0.0]],
+        ]
+    )
+    q_vec = np.array([2 * np.pi, 0.0, 0.0])
+    weights = np.array([1.0, 2.0])
+
+    phase = phase_factors(positions, q_vec)
+    expected = phase @ weights
+
+    np.testing.assert_allclose(density_amplitude(positions, q_vec, weights), expected)
+    np.testing.assert_allclose(density_amplitude_from_phase(phase, weights), expected)
+
+
+def test_fft_power_and_circular_autocorrelation_are_consistent():
+    signal = np.array([1.0 + 0.0j, 0.0 + 1.0j, -1.0 + 0.0j, 0.0 - 1.0j])
+
+    direct = fft_power(signal, norm="forward")
+    correlation = circular_autocorrelation(signal)
+    via_correlation = fft(correlation, norm="forward").real
+
+    np.testing.assert_allclose(direct, via_correlation)
+
+
+def test_frequency_grid_and_standard_error():
+    grid = frequency_grid(block_size=8, dt=1e-12, positive_only=True)
+    np.testing.assert_allclose(grid.frequencies_thz, [0.0, 0.125, 0.25, 0.375])
+
+    samples = np.array([[1.0, 2.0], [3.0, 6.0], [5.0, 10.0]])
+    expected = np.std(samples, axis=0, ddof=1) / np.sqrt(3.0)
+    np.testing.assert_allclose(standard_error(samples), expected)

--- a/tests/test_scattering_plot.py
+++ b/tests/test_scattering_plot.py
@@ -1,0 +1,83 @@
+import matplotlib
+
+matplotlib.use("Agg")
+
+import numpy as np
+import pytest
+
+from pySED.compare_experiment import ScatteringMap, prepare_map_comparison
+from pySED.scattering_plot import plot_linecuts, plot_map_comparison, plot_scattering_map
+
+
+def _comparison():
+    simulated = ScatteringMap(
+        q_axis=np.array([0.0, 0.5, 1.0]),
+        energy_axis=np.array([0.0, 1.0, 2.0, 3.0]),
+        intensity=np.array(
+            [
+                [0.0, 1.0, 2.0, 1.0],
+                [1.0, 3.0, 4.0, 2.0],
+                [0.5, 1.5, 2.5, 1.0],
+            ]
+        ),
+    )
+    experimental = ScatteringMap(
+        q_axis=simulated.q_axis,
+        energy_axis=simulated.energy_axis,
+        intensity=simulated.intensity * 0.8,
+    )
+    return prepare_map_comparison(simulated, experimental)
+
+
+def test_plot_scattering_map_saves_png(tmp_path):
+    comparison = _comparison()
+    path = tmp_path / "map.png"
+
+    fig, ax, image = plot_scattering_map(comparison.simulated_map, save_path=path)
+
+    assert path.exists()
+    assert path.stat().st_size > 0
+    assert image.get_array().shape == (4, 3)
+    assert ax.get_xlabel() == "Q path"
+    fig.clear()
+
+
+def test_plot_linecuts_saves_png(tmp_path):
+    comparison = _comparison()
+    path = tmp_path / "linecuts.png"
+
+    fig, ax = plot_linecuts(
+        comparison.simulated_map,
+        experimental_map=comparison.experimental_map,
+        q_indices=[0, 2],
+        save_path=path,
+    )
+
+    assert path.exists()
+    assert path.stat().st_size > 0
+    assert len(ax.lines) == 4
+    fig.clear()
+
+
+def test_plot_map_comparison_saves_summary_png(tmp_path):
+    comparison = _comparison()
+    path = tmp_path / "comparison.png"
+
+    fig = plot_map_comparison(comparison, save_path=path, q_indices=[1])
+
+    assert path.exists()
+    assert path.stat().st_size > 0
+    assert len(fig.axes) >= 4
+    fig.clear()
+
+
+def test_plot_linecuts_requires_aligned_maps():
+    comparison = _comparison()
+    experimental = ScatteringMap(
+        q_axis=np.array([0.0, 0.5]),
+        energy_axis=comparison.experimental_map.energy_axis,
+        intensity=np.ones((2, 4)),
+    )
+
+    with pytest.raises(ValueError, match="aligned"):
+        plot_linecuts(comparison.simulated_map, experimental_map=experimental)

--- a/tests/test_scattering_workflow.py
+++ b/tests/test_scattering_workflow.py
@@ -1,0 +1,569 @@
+import numpy as np
+import pytest
+
+from pySED.compare_experiment import ScatteringMap
+from pySED.eigen_sed import EigenvectorSet
+from pySED.scattering_workflow import (
+    compute_current_correlation_workflow,
+    compute_dsf_workflow,
+    compute_eels_workflow,
+    compute_eels_workflow_from_angle_axis,
+    compute_eels_workflow_from_q_path,
+    compute_one_phonon_workflow,
+    compute_one_phonon_workflow_from_q_path,
+    compute_partial_dsf_workflow,
+    current_correlation_to_scattering_map,
+    dsf_to_scattering_map,
+    eels_map_to_scattering_map,
+    one_phonon_map_to_scattering_map,
+    partial_dsf_to_scattering_map,
+)
+from pySED.electron_kinematics import electron_wavenumber_per_angstrom
+from pySED.visibility_diagnostics import diagnose_mode_visibility
+
+
+def _single_mode_inputs(qpoint=(0.0, 0.0, 0.0)):
+    n_frames = 32
+    dt = 1e-12
+    target_bin = 4
+    time = np.arange(n_frames) * dt
+    freq_hz = target_bin / (n_frames * dt)
+
+    velocities = np.zeros((n_frames, 1, 3), dtype=float)
+    velocities[:, 0, 0] = np.cos(2 * np.pi * freq_hz * time)
+    eig = np.zeros((1, 1, 1, 3), dtype=complex)
+    eig[0, 0, 0, 0] = 1.0
+    eigset = EigenvectorSet(
+        qpoints_reduced=np.array([qpoint], dtype=float),
+        frequencies=np.array([[freq_hz / 1e12]], dtype=float),
+        eigenvectors=eig,
+    )
+
+    return {
+        "velocities": velocities,
+        "unitcell_vectors": np.zeros((1, 3), dtype=float),
+        "basis_index": np.array([1]),
+        "masses": np.array([1.0]),
+        "primitive_cell": np.eye(3),
+        "supercell_cell": np.eye(3),
+        "eigenvectors": eigset,
+        "basis_positions_reduced": np.array([[0.0, 0.0, 0.0]]),
+        "g_vectors_reduced": np.array([[1.0, 0.0, 0.0]]),
+        "dt": dt,
+    }
+
+
+def test_compute_eels_workflow_builds_scattering_map_and_comparison():
+    inputs = _single_mode_inputs()
+    preliminary = compute_eels_workflow(**inputs)
+    experimental = ScatteringMap(
+        preliminary.scattering_map.q_axis,
+        preliminary.scattering_map.energy_axis,
+        preliminary.scattering_map.intensity.copy(),
+    )
+
+    result = compute_eels_workflow(**inputs, experimental_map=experimental)
+
+    assert result.eigen_sed.sed.shape[1:] == (1, 1)
+    assert result.eels_map.intensity.shape[:2] == (1, 1)
+    assert result.scattering_map.intensity.shape == (1, result.eigen_sed.frequencies_thz.size)
+    assert result.comparison.rmse == pytest.approx(0.0)
+    assert hasattr(result.visibility, "atom_visibility")
+    diagnostics = diagnose_mode_visibility(result.visibility, q_advice=result.q_advice)
+    assert diagnostics.dominant_reason.shape == (1, 1, 1)
+
+
+def test_eels_workflow_rejects_non_commensurate_qpoints():
+    inputs = _single_mode_inputs(qpoint=(0.25, 0.0, 0.0))
+
+    with pytest.raises(ValueError, match="commensurate"):
+        compute_eels_workflow(**inputs)
+
+
+def test_eels_map_to_scattering_map_validates_g_index():
+    inputs = _single_mode_inputs()
+    result = compute_eels_workflow(**inputs)
+
+    with pytest.raises(ValueError, match="g_index"):
+        eels_map_to_scattering_map(result.eels_map, g_index=3)
+
+
+def test_eels_workflow_can_output_mev_axis():
+    inputs = _single_mode_inputs()
+    result = compute_eels_workflow(**inputs, output_energy_unit="meV", sed_backend="cpu")
+
+    np.testing.assert_allclose(
+        result.scattering_map.energy_axis,
+        result.eigen_sed.frequencies_thz * 4.135667696,
+    )
+    assert result.scattering_map.metadata["energy_unit"] == "meV"
+    assert result.eigen_sed.metadata["backend"] == "cpu"
+
+
+def test_eels_workflow_accepts_mott_bethe_electron_form_factor_model():
+    inputs = _single_mode_inputs()
+    result = compute_eels_workflow(
+        **inputs,
+        atom_types=["C"],
+        electron_form_factor_model="mott-bethe",
+    )
+
+    assert result.visibility.metadata["electron_form_factor_model"] == "mott-bethe"
+    assert result.eels_map.intensity.shape[:2] == (1, 1)
+    assert np.all(np.isfinite(result.eels_map.intensity))
+
+
+def test_eels_workflow_accepts_pairwise_extended_zone_q_path():
+    n_frames = 32
+    dt = 1e-12
+    velocities = np.zeros((n_frames, 4, 3), dtype=float)
+    velocities[:, :, 0] = 1.0
+    eig = np.zeros((2, 1, 1, 3), dtype=complex)
+    eig[:, 0, 0, 0] = 1.0
+    eigset = EigenvectorSet(
+        qpoints_reduced=np.array([[0.0, 0.0, 0.0], [0.25, 0.0, 0.0]]),
+        frequencies=np.array([[0.0], [0.0]], dtype=float),
+        eigenvectors=eig,
+    )
+
+    result = compute_eels_workflow(
+        velocities=velocities,
+        unitcell_vectors=np.array(
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0], [3.0, 0.0, 0.0]]
+        ),
+        basis_index=np.array([1, 1, 1, 1]),
+        masses=np.array([1.0]),
+        primitive_cell=np.eye(3),
+        supercell_cell=np.diag([4.0, 1.0, 1.0]),
+        eigenvectors=eigset,
+        basis_positions_reduced=np.array([[0.0, 0.0, 0.0]]),
+        g_vectors_reduced=np.array([[1.0, 0.0, 0.0], [2.0, 0.0, 0.0]]),
+        dt=dt,
+        pairwise_g_vectors=True,
+    )
+
+    assert result.eels_map.intensity.shape[:2] == (2, 1)
+    np.testing.assert_allclose(result.visibility.Q_reduced[:, 0, :], [[1.0, 0.0, 0.0], [2.25, 0.0, 0.0]])
+    assert result.visibility.metadata["pairwise_g_vectors"] is True
+
+
+def test_eels_workflow_from_experimental_q_path_builds_q_plan():
+    n_frames = 32
+    dt = 1e-12
+    velocities = np.zeros((n_frames, 4, 3), dtype=float)
+    velocities[:, :, 0] = 1.0
+    eig = np.zeros((2, 1, 1, 3), dtype=complex)
+    eig[:, 0, 0, 0] = 1.0
+    eigset = EigenvectorSet(
+        qpoints_reduced=np.array([[0.0, 0.0, 0.0], [0.25, 0.0, 0.0]]),
+        frequencies=np.array([[0.0], [0.0]], dtype=float),
+        eigenvectors=eig,
+    )
+
+    result = compute_eels_workflow_from_q_path(
+        velocities=velocities,
+        unitcell_vectors=np.array(
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0], [3.0, 0.0, 0.0]]
+        ),
+        basis_index=np.array([1, 1, 1, 1]),
+        masses=np.array([1.0]),
+        primitive_cell=np.eye(3),
+        supercell_cell=np.diag([4.0, 1.0, 1.0]),
+        eigenvectors=eigset,
+        basis_positions_reduced=np.array([[0.0, 0.0, 0.0]]),
+        experimental_qpoints=np.array([[1.0 * 2.0 * np.pi, 0.0, 0.0], [2.25 * 2.0 * np.pi, 0.0, 0.0]]),
+        dt=dt,
+        qpoint_coordinates="cartesian",
+    )
+
+    np.testing.assert_allclose(result.q_plan.qpoints_reduced, [[0.0, 0.0, 0.0], [0.25, 0.0, 0.0]])
+    np.testing.assert_array_equal(result.q_plan.g_vectors_reduced, [[1, 0, 0], [2, 0, 0]])
+    np.testing.assert_allclose(result.visibility.Q_reduced[:, 0, :], result.q_plan.Q_reduced)
+    assert result.visibility.metadata["pairwise_g_vectors"] is True
+    assert result.eigen_sed.metadata["q_plan"] == "experimental extended-zone Q path folded to commensurate q"
+
+
+def test_eels_workflow_from_angle_axis_builds_q_plan():
+    n_frames = 32
+    dt = 1e-12
+    beam_energy = 200000.0
+    velocities = np.zeros((n_frames, 4, 3), dtype=float)
+    velocities[:, :, 0] = 1.0
+    eig = np.zeros((2, 1, 1, 3), dtype=complex)
+    eig[:, 0, 0, 0] = 1.0
+    eigset = EigenvectorSet(
+        qpoints_reduced=np.array([[0.0, 0.0, 0.0], [0.25, 0.0, 0.0]]),
+        frequencies=np.array([[0.0], [0.0]], dtype=float),
+        eigenvectors=eig,
+    )
+    k0 = electron_wavenumber_per_angstrom(beam_energy)
+    angle_axis_mrad = np.array([0.0, (0.25 * 2.0 * np.pi / k0) * 1000.0])
+
+    result = compute_eels_workflow_from_angle_axis(
+        velocities=velocities,
+        unitcell_vectors=np.array(
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0], [3.0, 0.0, 0.0]]
+        ),
+        basis_index=np.array([1, 1, 1, 1]),
+        masses=np.array([1.0]),
+        primitive_cell=np.eye(3),
+        supercell_cell=np.diag([4.0, 1.0, 1.0]),
+        eigenvectors=eigset,
+        basis_positions_reduced=np.array([[0.0, 0.0, 0.0]]),
+        angle_axis=angle_axis_mrad,
+        beam_energy_ev=beam_energy,
+        dt=dt,
+        q_policy="strict",
+    )
+
+    np.testing.assert_allclose(result.q_plan.qpoints_reduced, [[0.0, 0.0, 0.0], [0.25, 0.0, 0.0]])
+    np.testing.assert_array_equal(result.q_plan.g_vectors_reduced, [[0, 0, 0], [0, 0, 0]])
+    assert result.eigen_sed.metadata["q_plan_source"] == "electron scattering angle axis"
+    assert result.visibility.metadata["beam_energy_ev"] == beam_energy
+
+
+def test_eels_workflow_from_experimental_q_path_rejects_non_commensurate_strict():
+    inputs = _single_mode_inputs()
+
+    with pytest.raises(ValueError, match="non-commensurate"):
+        compute_eels_workflow_from_q_path(
+            velocities=inputs["velocities"],
+            unitcell_vectors=inputs["unitcell_vectors"],
+            basis_index=inputs["basis_index"],
+            masses=inputs["masses"],
+            primitive_cell=np.eye(3),
+            supercell_cell=np.diag([4.0, 1.0, 1.0]),
+            eigenvectors=inputs["eigenvectors"],
+            basis_positions_reduced=inputs["basis_positions_reduced"],
+            experimental_qpoints=np.array([[0.26, 0.0, 0.0]]),
+            dt=inputs["dt"],
+            qpoint_coordinates="reduced",
+            q_policy="strict",
+        )
+
+
+def test_compute_one_phonon_workflow_builds_scattering_map_and_comparison():
+    inputs = _single_mode_inputs()
+    preliminary = compute_one_phonon_workflow(**inputs, experiment="custom", sed_backend="cpu")
+    experimental = ScatteringMap(
+        preliminary.scattering_map.q_axis,
+        preliminary.scattering_map.energy_axis,
+        preliminary.scattering_map.intensity.copy(),
+    )
+
+    result = compute_one_phonon_workflow(
+        **inputs,
+        experiment="custom",
+        sed_backend="cpu",
+        experimental_map=experimental,
+    )
+
+    assert result.eigen_sed.sed.shape[1:] == (1, 1)
+    assert result.one_phonon_map.intensity.shape[:2] == (1, 1)
+    assert result.scattering_map.intensity.shape == (1, result.eigen_sed.frequencies_thz.size)
+    assert result.comparison.rmse == pytest.approx(0.0)
+    assert result.eigen_sed.metadata["backend"] == "cpu"
+
+
+def test_one_phonon_workflow_from_experimental_q_path_builds_q_plan():
+    n_frames = 32
+    dt = 1e-12
+    velocities = np.zeros((n_frames, 4, 3), dtype=float)
+    velocities[:, :, 0] = 1.0
+    eig = np.zeros((2, 1, 1, 3), dtype=complex)
+    eig[:, 0, 0, 0] = 1.0
+    eigset = EigenvectorSet(
+        qpoints_reduced=np.array([[0.0, 0.0, 0.0], [0.25, 0.0, 0.0]]),
+        frequencies=np.array([[1.0], [1.0]], dtype=float),
+        eigenvectors=eig,
+    )
+
+    result = compute_one_phonon_workflow_from_q_path(
+        velocities=velocities,
+        unitcell_vectors=np.array(
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0], [3.0, 0.0, 0.0]]
+        ),
+        basis_index=np.array([1, 1, 1, 1]),
+        masses=np.array([1.0]),
+        primitive_cell=np.eye(3),
+        supercell_cell=np.diag([4.0, 1.0, 1.0]),
+        eigenvectors=eigset,
+        basis_positions_reduced=np.array([[0.0, 0.0, 0.0]]),
+        experimental_qpoints=np.array([[1.0 * 2.0 * np.pi, 0.0, 0.0], [2.25 * 2.0 * np.pi, 0.0, 0.0]]),
+        dt=dt,
+        qpoint_coordinates="cartesian",
+        experiment="custom",
+    )
+
+    np.testing.assert_allclose(result.q_plan.qpoints_reduced, [[0.0, 0.0, 0.0], [0.25, 0.0, 0.0]])
+    np.testing.assert_array_equal(result.q_plan.g_vectors_reduced, [[1, 0, 0], [2, 0, 0]])
+    np.testing.assert_allclose(result.visibility.Q_reduced[:, 0, :], result.q_plan.Q_reduced)
+    assert result.one_phonon_map.intensity.shape[:2] == (2, 1)
+    assert result.visibility.metadata["pairwise_g_vectors"] is True
+
+
+def test_one_phonon_workflow_from_experimental_q_path_rejects_non_commensurate_strict():
+    inputs = _single_mode_inputs()
+
+    with pytest.raises(ValueError, match="non-commensurate"):
+        compute_one_phonon_workflow_from_q_path(
+            velocities=inputs["velocities"],
+            unitcell_vectors=inputs["unitcell_vectors"],
+            basis_index=inputs["basis_index"],
+            masses=inputs["masses"],
+            primitive_cell=np.eye(3),
+            supercell_cell=np.diag([4.0, 1.0, 1.0]),
+            eigenvectors=inputs["eigenvectors"],
+            basis_positions_reduced=inputs["basis_positions_reduced"],
+            experimental_qpoints=np.array([[0.26, 0.0, 0.0]]),
+            dt=inputs["dt"],
+            qpoint_coordinates="reduced",
+            q_policy="strict",
+            experiment="custom",
+        )
+
+
+def test_one_phonon_map_to_scattering_map_validates_g_index():
+    inputs = _single_mode_inputs()
+    result = compute_one_phonon_workflow(**inputs, experiment="custom")
+
+    with pytest.raises(ValueError, match="g_index"):
+        one_phonon_map_to_scattering_map(result.one_phonon_map, g_index=2)
+
+
+def test_dsf_workflow_rejects_non_commensurate_qpoints_in_strict_mode():
+    positions = np.zeros((16, 1, 3), dtype=float)
+
+    with pytest.raises(ValueError, match="commensurate"):
+        compute_dsf_workflow(
+            positions,
+            qpoints=np.array([[0.20, 0.0, 0.0]]),
+            primitive_cell=np.eye(3),
+            supercell_cell=np.diag([4.0, 1.0, 1.0]),
+            dt=1e-12,
+            qpoint_coordinates="reduced",
+            q_policy="strict",
+            experiment="custom",
+        )
+
+
+def test_dsf_workflow_maps_nearest_commensurate_qpoints():
+    positions = np.zeros((16, 1, 3), dtype=float)
+    result = compute_dsf_workflow(
+        positions,
+        qpoints=np.array([[0.26, 0.0, 0.0]]),
+        primitive_cell=np.eye(3),
+        supercell_cell=np.diag([4.0, 1.0, 1.0]),
+        dt=1e-12,
+        qpoint_coordinates="reduced",
+        q_policy="nearest",
+        max_error_reduced=0.02,
+        experiment="custom",
+    )
+
+    np.testing.assert_allclose(result.qpoints_reduced, [[0.25, 0.0, 0.0]])
+    np.testing.assert_allclose(result.qpoints_cartesian, [[0.5 * np.pi, 0.0, 0.0]])
+    assert result.dsf.metadata["q_policy"] == "nearest"
+
+
+def test_dsf_workflow_preserves_extended_zone_cartesian_q_mapping():
+    positions = np.zeros((16, 1, 3), dtype=float)
+    cartesian_q = np.array([[1.26 * 2.0 * np.pi, 0.0, 0.0]])
+
+    result = compute_dsf_workflow(
+        positions,
+        qpoints=cartesian_q,
+        primitive_cell=np.eye(3),
+        supercell_cell=np.diag([4.0, 1.0, 1.0]),
+        dt=1e-12,
+        qpoint_coordinates="cartesian",
+        q_policy="nearest",
+        experiment="custom",
+    )
+
+    np.testing.assert_allclose(result.qpoints_reduced, [[1.25, 0.0, 0.0]])
+    np.testing.assert_allclose(result.qpoints_cartesian, [[2.5 * np.pi, 0.0, 0.0]])
+    np.testing.assert_allclose(result.dsf.qpoints_cartesian, result.qpoints_cartesian)
+
+
+def test_dsf_workflow_builds_scattering_map_and_comparison():
+    positions = np.zeros((16, 1, 3), dtype=float)
+    preliminary = compute_dsf_workflow(
+        positions,
+        qpoints=np.array([[0.0, 0.0, 0.0], [0.25, 0.0, 0.0]]),
+        primitive_cell=np.eye(3),
+        supercell_cell=np.diag([4.0, 1.0, 1.0]),
+        dt=1e-12,
+        qpoint_coordinates="reduced",
+        q_policy="strict",
+        experiment="custom",
+    )
+    experimental = ScatteringMap(
+        preliminary.scattering_map.q_axis,
+        preliminary.scattering_map.energy_axis,
+        preliminary.scattering_map.intensity.copy(),
+    )
+
+    result = compute_dsf_workflow(
+        positions,
+        qpoints=np.array([[0.0, 0.0, 0.0], [0.25, 0.0, 0.0]]),
+        primitive_cell=np.eye(3),
+        supercell_cell=np.diag([4.0, 1.0, 1.0]),
+        dt=1e-12,
+        qpoint_coordinates="reduced",
+        q_policy="strict",
+        experiment="custom",
+        experimental_map=experimental,
+    )
+
+    assert result.scattering_map.intensity.shape == result.dsf.total.shape
+    assert result.scattering_map.metadata["component"] == "total"
+    assert result.comparison.rmse == pytest.approx(0.0)
+
+
+def test_dsf_to_scattering_map_can_select_component_and_energy_unit():
+    positions = np.zeros((16, 1, 3), dtype=float)
+    result = compute_dsf_workflow(
+        positions,
+        qpoints=np.array([[0.0, 0.0, 0.0]]),
+        primitive_cell=np.eye(3),
+        supercell_cell=np.eye(3),
+        dt=1e-12,
+        qpoint_coordinates="reduced",
+        q_policy="strict",
+        experiment="custom",
+    )
+
+    scattering_map = dsf_to_scattering_map(
+        result.dsf,
+        component="coherent",
+        output_energy_unit="meV",
+    )
+
+    np.testing.assert_allclose(scattering_map.intensity, result.dsf.coherent)
+    np.testing.assert_allclose(scattering_map.energy_axis, result.dsf.frequencies_thz * 4.135667696)
+    assert scattering_map.metadata["component"] == "coherent"
+    assert scattering_map.metadata["energy_unit"] == "meV"
+
+
+def test_dsf_to_scattering_map_rejects_unknown_component():
+    positions = np.zeros((16, 1, 3), dtype=float)
+    result = compute_dsf_workflow(
+        positions,
+        qpoints=np.array([[0.0, 0.0, 0.0]]),
+        primitive_cell=np.eye(3),
+        supercell_cell=np.eye(3),
+        dt=1e-12,
+        qpoint_coordinates="reduced",
+        q_policy="strict",
+        experiment="custom",
+    )
+
+    with pytest.raises(ValueError, match="component"):
+        dsf_to_scattering_map(result.dsf, component="bad")
+
+
+def test_partial_dsf_workflow_builds_weighted_total_and_species_pair_maps():
+    n_frames = 16
+    dt = 1e-12
+    positions = np.zeros((n_frames, 2, 3), dtype=float)
+    positions[:, 1, 0] = np.linspace(0.0, 0.5, n_frames)
+
+    result = compute_partial_dsf_workflow(
+        positions,
+        qpoints=np.array([[0.25, 0.0, 0.0]]),
+        primitive_cell=np.eye(3),
+        supercell_cell=np.diag([4.0, 1.0, 1.0]),
+        dt=dt,
+        atom_types=["A", "B"],
+        qpoint_coordinates="reduced",
+        q_policy="strict",
+        species_weights={"A": 1.0, "B": 2.0},
+        num_blocks=2,
+    )
+
+    assert result.scattering_map.intensity.shape == result.partial_dsf.weighted_total.shape
+    assert result.scattering_map.metadata["source"] == "pySED PartialDSFResult"
+    assert result.partial_dsf.metadata["q_policy"] == "strict"
+
+    pair_map = partial_dsf_to_scattering_map(
+        result.partial_dsf,
+        component="partial",
+        species_pair=("A", "B"),
+        complex_part="abs",
+        output_energy_unit="meV",
+    )
+
+    assert pair_map.metadata["species_pair"] == ("A", "B")
+    assert pair_map.metadata["complex_part"] == "abs"
+    np.testing.assert_allclose(pair_map.energy_axis, result.partial_dsf.frequencies_thz * 4.135667696)
+    assert np.all(pair_map.intensity >= 0.0)
+
+
+def test_partial_dsf_to_scattering_map_rejects_missing_species_pair():
+    positions = np.zeros((8, 2, 3), dtype=float)
+    result = compute_partial_dsf_workflow(
+        positions,
+        qpoints=np.array([[0.0, 0.0, 0.0]]),
+        primitive_cell=np.eye(3),
+        supercell_cell=np.eye(3),
+        dt=1e-12,
+        atom_types=["A", "B"],
+        qpoint_coordinates="reduced",
+        q_policy="strict",
+    )
+
+    with pytest.raises(ValueError, match="species_pair"):
+        partial_dsf_to_scattering_map(result.partial_dsf, component="partial")
+
+
+def test_current_correlation_workflow_builds_scattering_map_and_sem():
+    n_frames = 16
+    dt = 1e-12
+    positions = np.zeros((n_frames, 1, 3), dtype=float)
+    velocities = np.zeros_like(positions)
+    velocities[:, 0, 0] = 1.0
+
+    preliminary = compute_current_correlation_workflow(
+        positions,
+        velocities,
+        qpoints=np.array([[0.25, 0.0, 0.0]]),
+        primitive_cell=np.eye(3),
+        supercell_cell=np.diag([4.0, 1.0, 1.0]),
+        dt=dt,
+        qpoint_coordinates="reduced",
+        q_policy="strict",
+        num_blocks=2,
+    )
+    experimental = ScatteringMap(
+        preliminary.scattering_map.q_axis,
+        preliminary.scattering_map.energy_axis,
+        preliminary.scattering_map.intensity.copy(),
+    )
+    result = compute_current_correlation_workflow(
+        positions,
+        velocities,
+        qpoints=np.array([[0.25, 0.0, 0.0]]),
+        primitive_cell=np.eye(3),
+        supercell_cell=np.diag([4.0, 1.0, 1.0]),
+        dt=dt,
+        qpoint_coordinates="reduced",
+        q_policy="strict",
+        num_blocks=2,
+        experimental_map=experimental,
+    )
+
+    assert result.scattering_map.intensity.shape == result.current.longitudinal.shape
+    assert result.current.longitudinal_sem.shape == result.current.longitudinal.shape
+    assert result.current.metadata["q_policy"] == "strict"
+    assert result.comparison.rmse == pytest.approx(0.0)
+
+    transverse_map = current_correlation_to_scattering_map(
+        result.current,
+        component="transverse",
+        output_energy_unit="meV",
+    )
+
+    np.testing.assert_allclose(transverse_map.intensity, result.current.transverse)
+    np.testing.assert_allclose(transverse_map.energy_axis, result.current.frequencies_thz * 4.135667696)
+    assert transverse_map.metadata["component"] == "transverse"

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,160 @@
+import json
+
+import numpy as np
+
+from pySED.validation import (
+    build_dsf_validation_report,
+    compare_arrays,
+    compare_external_dsf_reference,
+    compare_reference_spectrum,
+    compute_pysed_validation_pair,
+    export_dsf_validation_case,
+    load_dsf_validation_case,
+    package_status,
+    run_internal_dsf_reference_validation,
+    synthetic_dsf_validation_case,
+    write_validation_report,
+)
+
+
+def test_internal_dsf_validation_report_passes():
+    report = run_internal_dsf_reference_validation()
+
+    assert report["passed"]
+    assert report["checks"]["coherent"]["max_abs"] < 1e-12
+    assert report["num_qpoints"] == 2
+
+
+def test_build_dsf_validation_report_contains_environment_and_external_status():
+    report = build_dsf_validation_report()
+
+    assert report["passed"]
+    assert "python" in report["environment"]
+    assert "packages" in report["external"]
+    assert any(package["module"] == "dynasor" for package in report["external"]["packages"])
+
+
+def test_write_validation_report_json(tmp_path):
+    path = tmp_path / "validation.json"
+    report = build_dsf_validation_report()
+    write_validation_report(report, path)
+
+    with open(path, "r", encoding="utf-8") as handle:
+        loaded = json.load(handle)
+    assert loaded["passed"] is True
+    assert loaded["internal"]["name"] == "pysed_direct_vs_explicit_correlation"
+
+
+def test_export_and_load_dsf_validation_case(tmp_path):
+    path = tmp_path / "case.npz"
+    case = synthetic_dsf_validation_case(num_frames=16)
+
+    export_dsf_validation_case(path, case=case)
+    loaded = load_dsf_validation_case(path)
+    data = np.load(path)
+
+    np.testing.assert_allclose(loaded.positions, case.positions)
+    np.testing.assert_allclose(loaded.qpoints_cartesian, case.qpoints_cartesian)
+    assert loaded.num_blocks == case.num_blocks
+    assert "pysed_direct_coherent" in data.files
+    assert "pysed_reference_coherent" in data.files
+
+
+def test_compare_arrays_reports_shape_mismatch():
+    result = compare_arrays(np.zeros((2,)), np.zeros((3,)))
+
+    assert not result["passed"]
+    assert result["reason"] == "shape mismatch"
+
+
+def test_compare_reference_spectrum_exact_match():
+    spectrum = np.array([[0.0, 1.0, 0.25], [0.5, 0.0, 0.75]])
+
+    comparison = compare_reference_spectrum(spectrum, spectrum, normalization="none")
+
+    assert comparison.passed
+    assert comparison.rmse == 0.0
+    assert comparison.normalized_rmse == 0.0
+    assert comparison.correlation == 1.0
+
+
+def test_compare_reference_spectrum_least_squares_scale():
+    reference = np.array([[0.0, 1.0, 2.0], [3.0, 0.0, 1.0]])
+    candidate = 2.0 * reference
+
+    comparison = compare_reference_spectrum(candidate, reference, normalization="least_squares")
+
+    assert comparison.passed
+    assert comparison.scale_factor == 0.5
+    assert comparison.rmse == 0.0
+
+
+def test_compare_reference_spectrum_interpolates_frequency_axis():
+    candidate_frequencies = np.array([0.0, 1.0, 2.0])
+    reference_frequencies = np.array([0.0, 2.0])
+    candidate = np.array([[0.0, 1.0, 2.0]])
+    reference = np.array([[0.0, 2.0]])
+
+    comparison = compare_reference_spectrum(
+        candidate,
+        reference,
+        candidate_frequencies=candidate_frequencies,
+        reference_frequencies=reference_frequencies,
+        normalization="none",
+    )
+
+    assert comparison.passed
+    assert comparison.rmse == 0.0
+    assert comparison.peak_frequency_mae == 0.0
+
+
+def test_compare_reference_spectrum_shape_mismatch_without_frequencies():
+    comparison = compare_reference_spectrum(np.zeros((2, 3)), np.zeros((2, 4)))
+
+    assert not comparison.passed
+    assert comparison.reason == "shape mismatch and no frequency grids supplied for interpolation"
+
+
+def test_compare_reference_spectrum_non_finite_values_fail():
+    comparison = compare_reference_spectrum(np.array([1.0, np.nan]), np.array([1.0, 0.0]))
+
+    assert not comparison.passed
+    assert comparison.reason == "candidate or reference spectrum contains non-finite values"
+
+
+def test_compare_external_dsf_reference_npz_self_match(tmp_path):
+    path = tmp_path / "external_reference.npz"
+    case = synthetic_dsf_validation_case()
+    direct, _ = compute_pysed_validation_pair(case)
+    np.savez(path, coherent=direct.coherent, frequencies_thz=direct.frequencies_thz)
+
+    comparison = compare_external_dsf_reference(
+        path,
+        reference_key="coherent",
+        reference_frequency_key="frequencies_thz",
+        case=case,
+        normalization="none",
+        rmse_tolerance=1e-12,
+    )
+
+    assert comparison["passed"]
+    assert comparison["normalized_rmse"] == 0.0
+    assert comparison["reference_frequency_key"] == "frequencies_thz"
+
+
+def test_compare_external_dsf_reference_missing_frequency_key_raises(tmp_path):
+    path = tmp_path / "external_reference.npz"
+    np.savez(path, coherent=np.zeros((2, 32)))
+
+    try:
+        compare_external_dsf_reference(path, reference_frequency_key="missing")
+    except KeyError as exc:
+        assert "reference_frequency_key missing not found" in str(exc)
+    else:
+        raise AssertionError("missing reference frequency key should raise KeyError")
+
+
+def test_package_status_for_missing_module():
+    status = package_status("definitely_missing_pysed_validation_module")
+
+    assert status["installed"] is False

--- a/tests/test_visibility_diagnostics.py
+++ b/tests/test_visibility_diagnostics.py
@@ -1,0 +1,101 @@
+import csv
+
+import numpy as np
+import pytest
+
+from pySED.eels import compute_mode_visibility_decomposition
+from pySED.mode_visibility import compute_one_phonon_visibility
+from pySED.visibility_diagnostics import diagnose_mode_visibility
+
+
+def _two_atom_interference_case():
+    primitive = np.eye(3)
+    basis_positions = np.array([[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]])
+    masses = np.ones(2)
+    qpoints = np.array([[0.0, 0.0, 0.0]])
+    g_vectors = np.array([[1.0, 0.0, 0.0]])
+    eig = np.zeros((1, 2, 2, 3), dtype=complex)
+    eig[0, 0, :, 0] = [1.0, 1.0] / np.sqrt(2.0)
+    eig[0, 1, :, 0] = [1.0, -1.0] / np.sqrt(2.0)
+    return primitive, basis_positions, masses, qpoints, g_vectors, eig
+
+
+def test_eels_visibility_diagnostics_identify_basis_extinction():
+    primitive, basis_positions, masses, qpoints, g_vectors, eig = _two_atom_interference_case()
+    decomposition = compute_mode_visibility_decomposition(
+        qpoints,
+        g_vectors,
+        primitive,
+        basis_positions,
+        masses,
+        eig,
+    )
+
+    diagnostic = diagnose_mode_visibility(
+        decomposition,
+        atom_labels=["A", "B"],
+        mode_labels=["acoustic", "optic"],
+    )
+
+    assert diagnostic.dominant_reason[0, 0, 0] == "basis_interference"
+    assert diagnostic.dominant_reason[0, 0, 1] == "visible"
+    assert diagnostic.basis_interference_fraction[0, 0, 0] == pytest.approx(-1.0)
+    assert diagnostic.relative_visibility[0, 0, 1] == pytest.approx(1.0)
+
+    weak = diagnostic.weak_records()
+    assert len(weak) == 1
+    assert weak[0]["mode_label"] == "acoustic"
+    assert weak[0]["dominant_atom_label"] in ("A", "B")
+
+
+def test_one_phonon_visibility_diagnostics_write_csv(tmp_path):
+    primitive, basis_positions, masses, qpoints, g_vectors, eig = _two_atom_interference_case()
+    visibility = compute_one_phonon_visibility(
+        qpoints,
+        g_vectors,
+        primitive,
+        basis_positions,
+        masses,
+        eig,
+        experiment="custom",
+    )
+    diagnostic = diagnose_mode_visibility(visibility, atom_labels=["A", "B"])
+
+    path = tmp_path / "visibility_diagnostics.csv"
+    diagnostic.write_csv(path, include_all=False)
+
+    with open(path, "r", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    assert len(rows) == 1
+    assert rows[0]["dominant_reason"] == "basis_interference"
+    assert rows[0]["q_error_cartesian"] == "0.0"
+
+
+def test_visibility_diagnostics_report_finite_size_mapping_as_reason():
+    primitive, basis_positions, masses, qpoints, g_vectors, eig = _two_atom_interference_case()
+    decomposition = compute_mode_visibility_decomposition(
+        qpoints,
+        g_vectors,
+        primitive,
+        basis_positions,
+        masses,
+        eig,
+    )
+
+    class Advice:
+        error_reduced = 0.125
+        error_cartesian = 0.25
+
+    diagnostic = diagnose_mode_visibility(decomposition, q_advice=[Advice()])
+
+    assert diagnostic.dominant_reason[0, 0, 0] == "finite_size_q_mapping"
+    assert diagnostic.q_error_reduced[0] == pytest.approx(0.125)
+    assert diagnostic.q_error_cartesian[0] == pytest.approx(0.25)
+
+
+def test_visibility_diagnostics_reject_plain_visibility_without_decomposition():
+    class PlainVisibility:
+        visibility = np.zeros((1, 1, 1))
+
+    with pytest.raises(ValueError, match="missing"):
+        diagnose_mode_visibility(PlainVisibility())


### PR DESCRIPTION
﻿## What changed

This PR adds the first pySED-native scattering foundation for experiment-facing workflows:

- q-advisor utilities for commensurate Q validation, nearest-Q mapping, extended-zone Q = q + G planning, and selected-Q efficiency reporting.
- Shared scattering kernels and workflow modules for DSF, current correlations, eigenvector-projected SED, one-phonon visibility, EELS visibility, map comparison, plotting/export, and validation helpers.
- `input_SED.in` support for `scattering = 1` with `scattering_mode = q_advisor`, including path/mesh/file/inline Q-point sources, strict/nearest policy, and report file generation.
- Documentation pages for the scattering theory/API and input-file q-advisor usage.
- Focused tests and a benchmark script for direct DSF versus the correlation reference route.

## Why

The goal is to make pySED a native route from MD trajectories to experiment-comparable phonon scattering maps, while keeping the finite-supercell commensurability decision explicit before DSF/EELS calculations are interpreted against experiments.

## User impact

Users can now run a q-advisor check directly from `input_SED.in` before scattering workflows. The CLI writes CSV/text summaries, nearest commensurate Q points, and folded phonopy Q points for later DSF/EELS/mode-visibility workflows.

## Validation

- `python -m pytest -q` -> 135 passed
- `python -m sphinx -b html docs\source docs\_build\html` -> build succeeded
- `python benchmarks\dsf_reference_validation.py` -> direct-vs-correlation max_abs = 2.7755575615628914e-17
- CLI smoke test for `python -m pySED.main input_SED.in` with `scattering = 1` -> q-advisor files generated

External dynasor/pynamic comparison packages were not installed in this local environment, so the benchmark only ran the internal direct-vs-correlation reference check.
