### PR TITLE
[codex] Fix qNEP citation in theory documentation

### DIFF
--- a/docs/source/theory.rst
+++ b/docs/source/theory.rst
@@ -318,6 +318,9 @@ References
    Communications* **316**, 109759 (2025).
    https://doi.org/10.1016/j.cpc.2025.109759
 
-.. [qNEP2026] X. Wu, T. Liang, W. Wang, J. Ma, Z. Fan, J. Xu, S. Volz,
-   and M. Nomura, "Data-driven flipping engineering for high thermal
-   anisotropy." https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5864374
+.. [qNEP2026] Z. Fan, B. Tang, E. Berger, E. Berger, E. Fransson, K. Xu,
+   Z. Yan, Z. Liu, Z. Song, H. Dong, S. Chen, L. Li, Z. Wang, Y. Zhu,
+   J. Wiktor, and P. Erhart, "qNEP: A highly efficient neuroevolution
+   potential with dynamic charges for large-scale atomistic simulations,"
+   *Journal of Chemical Theory and Computation* **22**, 4787-4801 (2026).
+   https://doi.org/10.1021/acs.jctc.6c00146


### PR DESCRIPTION
## Summary

- replace the incorrect `[qNEP2026]` reference in the theory documentation
- cite the published qNEP article in *Journal of Chemical Theory and Computation*
- link the reference to DOI `10.1021/acs.jctc.6c00146`

## Root cause

The qNEP reference accidentally contained the authors, title, and SSRN URL of a different thermal-anisotropy paper.

## Validation

- `python -m sphinx -W --keep-going -b html source build\html`
- `git diff --check`