### PR TITLE
[codex] Add lithium niobate preprint

### DIFF
--- a/publications/readme.md
+++ b/publications/readme.md
@@ -1,6 +1,8 @@
 # Publications using pySED
 
-## Preprints (3)
+## Preprints (4)
+
+* Wenjiang Zhou, Fuwei Yang, Yuxi Wang, Weiheng Li, Wujuan Yan, Kexin Zhang, Bai Song, [Intrinsically low thermal conductivity of stoichiometric lithium niobate: Experimental measurement and microscopic origin](https://arxiv.org/abs/2607.01673)
 
 * Jianmin Yang, Lin Xie, [Lattice-mediated Geometric Frustration Drives Fast Ionic Transport](https://arxiv.org/abs/2606.22345)
 


### PR DESCRIPTION
﻿## Summary
- Add the arXiv 2607.01673 preprint to the pySED publications list.
- Update the preprint count from 3 to 4.

## Validation
- Verified arXiv metadata for title and authors.
- Ran `git diff --check -- publications/readme.md`.
- Confirmed the Preprints section contains 4 entries.
